### PR TITLE
feat(build): add dev container setups for Brick and A30

### DIFF
--- a/.devcontainer/a30/Dockerfile
+++ b/.devcontainer/a30/Dockerfile
@@ -1,0 +1,39 @@
+# adapted from https://github.com/shauninman/union-my282-toolchain/blob/main/Dockerfile
+FROM debian:buster-slim
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get -y update && apt-get -y install \
+	bc \
+    build-essential \
+    bzip2 \
+	bzr \
+	cmake \
+	cmake-curses-gui \
+	cpio \
+	device-tree-compiler \
+	git \
+	imagemagick \
+	libncurses5-dev \
+	locales \
+	make \
+	p7zip-full \
+	rsync \
+	sharutils \
+	scons \
+	tree \
+	unzip \
+	vim \
+	wget \
+	zip \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root
+
+COPY support .
+RUN ./build-toolchain.sh
+RUN cat ./setup-env.sh >> .bashrc
+
+CMD ["/bin/bash"]

--- a/.devcontainer/a30/devcontainer.json
+++ b/.devcontainer/a30/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "A30",
+  "build": { "dockerfile": "Dockerfile" }
+}

--- a/.devcontainer/a30/support/build-toolchain.sh
+++ b/.devcontainer/a30/support/build-toolchain.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+BUILDROOT_VERSION=2017.11
+
+set -xe
+
+if [ -d ~/buildroot ]; then
+	rm -rf ~/buildroot
+else
+	sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+	locale-gen
+fi
+
+cd ~
+
+BUILDROOT_NAME=buildroot-$BUILDROOT_VERSION
+wget https://buildroot.org/downloads/$BUILDROOT_NAME.tar.gz
+tar -xf ./$BUILDROOT_NAME.tar.gz
+rm -f ./$BUILDROOT_NAME.tar.gz
+mv ./$BUILDROOT_NAME ./buildroot
+
+# patches for buildroot packages
+cd ~/patches
+for FILE in $(find . -type f -name "*.patch" 2>/dev/null); do
+	cp $FILE ~/buildroot/$FILE
+done
+
+cd ~/buildroot
+# patches for buildroot itself
+patch -p1 < ~/sdl2-update-to-2.26.1.patch
+patch -p1 < ~/toolchain-expose-BR2_TOOLCHAIN_EXTRA_EXTERNAL_LIBS-for-all-toolchain-types-2017.11.1.diff
+
+cp ~/my282-buildroot-$BUILDROOT_VERSION.config ./.config
+if [ -f ~/my282-toolchain.tar.xz ]; then
+ 	tar -xf ~/my282-toolchain.tar.xz -C /opt
+else
+	export FORCE_UNSAFE_CONFIGURE=1
+	make oldconfig
+	make world
+	
+	~/install-toolchain.sh
+fi

--- a/.devcontainer/a30/support/install-toolchain.sh
+++ b/.devcontainer/a30/support/install-toolchain.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+mkdir -p /opt/my282-toolchain
+if [ -d /opt/my282-toolchain/usr ]; then
+	rm -fr /opt/my282-toolchain/usr
+fi
+cp -rf ~/buildroot/output/host/usr/ /opt/my282-toolchain/
+# this version of buildroot doesn't have relocate-sdk.sh yet so we bring our own
+cp ~/relocate-sdk.sh /opt/my282-toolchain/
+cp ~/sdk-location /opt/my282-toolchain/
+/opt/my282-toolchain/relocate-sdk.sh

--- a/.devcontainer/a30/support/my282-buildroot-2017.11.config
+++ b/.devcontainer/a30/support/my282-buildroot-2017.11.config
@@ -1,0 +1,2705 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Buildroot 2017.11 Configuration
+#
+BR2_HAVE_DOT_CONFIG=y
+
+#
+# Target options
+#
+BR2_ARCH_HAS_MMU_OPTIONAL=y
+# BR2_arcle is not set
+# BR2_arceb is not set
+BR2_arm=y
+# BR2_armeb is not set
+# BR2_aarch64 is not set
+# BR2_aarch64_be is not set
+# BR2_bfin is not set
+# BR2_csky is not set
+# BR2_i386 is not set
+# BR2_m68k is not set
+# BR2_microblazeel is not set
+# BR2_microblazebe is not set
+# BR2_mips is not set
+# BR2_mipsel is not set
+# BR2_mips64 is not set
+# BR2_mips64el is not set
+# BR2_nios2 is not set
+# BR2_or1k is not set
+# BR2_powerpc is not set
+# BR2_powerpc64 is not set
+# BR2_powerpc64le is not set
+# BR2_sh is not set
+# BR2_sparc is not set
+# BR2_sparc64 is not set
+# BR2_x86_64 is not set
+# BR2_xtensa is not set
+BR2_ARCH_HAS_TOOLCHAIN_BUILDROOT=y
+BR2_ARCH="arm"
+BR2_ENDIAN="LITTLE"
+BR2_GCC_TARGET_ABI="aapcs-linux"
+BR2_GCC_TARGET_CPU="cortex-a9"
+BR2_GCC_TARGET_FPU="neon"
+BR2_GCC_TARGET_FLOAT_ABI="hard"
+BR2_GCC_TARGET_MODE="thumb"
+BR2_BINFMT_SUPPORTS_SHARED=y
+BR2_READELF_ARCH_NAME="ARM"
+BR2_BINFMT_ELF=y
+BR2_ARM_CPU_HAS_NEON=y
+BR2_ARM_CPU_MAYBE_HAS_NEON=y
+BR2_ARM_CPU_MAYBE_HAS_VFPV2=y
+BR2_ARM_CPU_HAS_VFPV2=y
+BR2_ARM_CPU_MAYBE_HAS_VFPV3=y
+BR2_ARM_CPU_HAS_VFPV3=y
+BR2_ARM_CPU_HAS_ARM=y
+BR2_ARM_CPU_HAS_THUMB2=y
+BR2_ARM_CPU_ARMV7A=y
+# BR2_arm920t is not set
+# BR2_arm922t is not set
+# BR2_arm926t is not set
+# BR2_arm1136j_s is not set
+# BR2_arm1136jf_s is not set
+# BR2_arm1176jz_s is not set
+# BR2_arm1176jzf_s is not set
+# BR2_arm11mpcore is not set
+# BR2_cortex_a5 is not set
+# BR2_cortex_a7 is not set
+# BR2_cortex_a8 is not set
+BR2_cortex_a9=y
+# BR2_cortex_a12 is not set
+# BR2_cortex_a15 is not set
+# BR2_cortex_a15_a7 is not set
+# BR2_cortex_a17 is not set
+# BR2_cortex_a17_a7 is not set
+# BR2_cortex_a53 is not set
+# BR2_cortex_a57 is not set
+# BR2_cortex_a57_a53 is not set
+# BR2_cortex_a72 is not set
+# BR2_cortex_a72_a53 is not set
+# BR2_cortex_m3 is not set
+# BR2_cortex_m4 is not set
+# BR2_fa526 is not set
+# BR2_pj4 is not set
+# BR2_strongarm is not set
+# BR2_xscale is not set
+# BR2_iwmmxt is not set
+BR2_ARM_ENABLE_NEON=y
+BR2_ARM_ENABLE_VFP=y
+# BR2_ARM_EABI is not set
+BR2_ARM_EABIHF=y
+# BR2_ARM_FPU_VFPV2 is not set
+# BR2_ARM_FPU_VFPV3 is not set
+# BR2_ARM_FPU_VFPV3D16 is not set
+BR2_ARM_FPU_NEON=y
+# BR2_ARM_INSTRUCTIONS_ARM is not set
+BR2_ARM_INSTRUCTIONS_THUMB2=y
+
+#
+# Build options
+#
+
+#
+# Commands
+#
+BR2_WGET="wget --passive-ftp -nd -t 3"
+BR2_SVN="svn --non-interactive"
+BR2_BZR="bzr"
+BR2_GIT="git"
+BR2_CVS="cvs"
+BR2_LOCALFILES="cp"
+BR2_SCP="scp"
+BR2_SSH="ssh"
+BR2_HG="hg"
+BR2_ZCAT="gzip -d -c"
+BR2_BZCAT="bzcat"
+BR2_XZCAT="xzcat"
+BR2_LZCAT="lzip -d -c"
+BR2_TAR_OPTIONS=""
+BR2_DEFCONFIG="$(CONFIG_DIR)/defconfig"
+BR2_DL_DIR="$(TOPDIR)/dl"
+BR2_HOST_DIR="$(BASE_DIR)/host"
+
+#
+# Mirrors and Download locations
+#
+BR2_PRIMARY_SITE=""
+BR2_BACKUP_SITE="http://sources.buildroot.net"
+BR2_KERNEL_MIRROR="https://cdn.kernel.org/pub"
+BR2_GNU_MIRROR="http://ftpmirror.gnu.org"
+BR2_LUAROCKS_MIRROR="http://rocks.moonscript.org"
+BR2_CPAN_MIRROR="http://cpan.metacpan.org"
+BR2_JLEVEL=0
+# BR2_CCACHE is not set
+# BR2_ENABLE_DEBUG is not set
+BR2_STRIP_strip=y
+BR2_STRIP_EXCLUDE_FILES=""
+BR2_STRIP_EXCLUDE_DIRS=""
+# BR2_OPTIMIZE_0 is not set
+# BR2_OPTIMIZE_1 is not set
+# BR2_OPTIMIZE_2 is not set
+# BR2_OPTIMIZE_3 is not set
+# BR2_OPTIMIZE_G is not set
+BR2_OPTIMIZE_S=y
+BR2_SSP_NONE=y
+# BR2_SSP_REGULAR is not set
+# BR2_SSP_STRONG is not set
+# BR2_SSP_ALL is not set
+# BR2_STATIC_LIBS is not set
+BR2_SHARED_LIBS=y
+# BR2_SHARED_STATIC_LIBS is not set
+BR2_PACKAGE_OVERRIDE_FILE="$(CONFIG_DIR)/local.mk"
+BR2_GLOBAL_PATCH_DIR=""
+
+#
+# Advanced
+#
+BR2_COMPILER_PARANOID_UNSAFE_PATH=y
+# BR2_REPRODUCIBLE is not set
+
+#
+# Toolchain
+#
+BR2_TOOLCHAIN=y
+BR2_TOOLCHAIN_USES_GLIBC=y
+BR2_TOOLCHAIN_BUILDROOT=y
+# BR2_TOOLCHAIN_EXTERNAL is not set
+
+#
+# Toolchain Buildroot Options
+#
+BR2_TOOLCHAIN_BUILDROOT_VENDOR="buildroot"
+# BR2_TOOLCHAIN_BUILDROOT_UCLIBC is not set
+BR2_TOOLCHAIN_BUILDROOT_GLIBC=y
+# BR2_TOOLCHAIN_BUILDROOT_MUSL is not set
+BR2_TOOLCHAIN_BUILDROOT_LIBC="glibc"
+
+#
+# Kernel Header Options
+#
+# BR2_KERNEL_HEADERS_3_2 is not set
+# BR2_KERNEL_HEADERS_3_4 is not set
+BR2_KERNEL_HEADERS_3_10=y
+# BR2_KERNEL_HEADERS_3_12 is not set
+# BR2_KERNEL_HEADERS_4_1 is not set
+# BR2_KERNEL_HEADERS_4_4 is not set
+# BR2_KERNEL_HEADERS_4_9 is not set
+# BR2_KERNEL_HEADERS_4_10 is not set
+# BR2_KERNEL_HEADERS_4_11 is not set
+# BR2_KERNEL_HEADERS_4_12 is not set
+# BR2_KERNEL_HEADERS_4_13 is not set
+# BR2_KERNEL_HEADERS_VERSION is not set
+BR2_DEFAULT_KERNEL_HEADERS="3.10.108"
+BR2_PACKAGE_LINUX_HEADERS=y
+BR2_PACKAGE_GLIBC=y
+
+#
+# Binutils Options
+#
+# BR2_BINUTILS_VERSION_2_27_X is not set
+BR2_BINUTILS_VERSION_2_28_X=y
+# BR2_BINUTILS_VERSION_2_29_X is not set
+BR2_BINUTILS_VERSION="2.28.1"
+BR2_BINUTILS_ENABLE_LTO=y
+BR2_BINUTILS_EXTRA_CONFIG_OPTIONS=""
+
+#
+# GCC Options
+#
+# BR2_GCC_VERSION_4_9_X is not set
+# BR2_GCC_VERSION_5_X is not set
+# BR2_GCC_VERSION_6_X is not set
+BR2_GCC_VERSION_7_X=y
+BR2_GCC_ARCH_HAS_CONFIGURABLE_DEFAULTS=y
+BR2_GCC_SUPPORTS_FINEGRAINEDMTUNE=y
+BR2_GCC_VERSION="7.2.0"
+BR2_EXTRA_GCC_CONFIG_OPTIONS=""
+BR2_TOOLCHAIN_BUILDROOT_CXX=y
+# BR2_TOOLCHAIN_BUILDROOT_FORTRAN is not set
+BR2_GCC_ENABLE_LTO=y
+BR2_GCC_ENABLE_OPENMP=y
+# BR2_GCC_ENABLE_GRAPHITE is not set
+BR2_PACKAGE_HOST_GDB_ARCH_SUPPORTS=y
+
+#
+# Host GDB Options
+#
+# BR2_PACKAGE_HOST_GDB is not set
+
+#
+# Toolchain Generic Options
+#
+BR2_TOOLCHAIN_HAS_NATIVE_RPC=y
+BR2_USE_WCHAR=y
+BR2_ENABLE_LOCALE=y
+BR2_INSTALL_LIBSTDCPP=y
+BR2_TOOLCHAIN_HAS_THREADS=y
+BR2_TOOLCHAIN_HAS_THREADS_DEBUG=y
+BR2_TOOLCHAIN_HAS_THREADS_NPTL=y
+BR2_TOOLCHAIN_HAS_SHADOW_PASSWORDS=y
+BR2_TOOLCHAIN_HAS_SSP=y
+BR2_TOOLCHAIN_SUPPORTS_PIE=y
+# BR2_TOOLCHAIN_GLIBC_GCONV_LIBS_COPY is not set
+BR2_TOOLCHAIN_EXTRA_LIBS="libasan"
+BR2_TOOLCHAIN_HAS_FULL_GETTEXT=y
+BR2_USE_MMU=y
+BR2_TARGET_OPTIMIZATION=""
+BR2_TARGET_LDFLAGS=""
+# BR2_ECLIPSE_REGISTER is not set
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_0=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_1=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_2=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_3=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_4=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_5=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_6=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_7=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_8=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_9=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_10=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST="3.10"
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_3=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_4=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_5=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_6=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_7=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_8=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_9=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_5=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_6=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_7=y
+BR2_TOOLCHAIN_GCC_AT_LEAST="7"
+BR2_TOOLCHAIN_HAS_MNAN_OPTION=y
+BR2_TOOLCHAIN_HAS_MFPXX_OPTION=y
+BR2_TOOLCHAIN_HAS_SYNC_1=y
+BR2_TOOLCHAIN_HAS_SYNC_2=y
+BR2_TOOLCHAIN_HAS_SYNC_4=y
+BR2_TOOLCHAIN_ARM_HAS_SYNC_8=y
+BR2_TOOLCHAIN_HAS_SYNC_8=y
+BR2_TOOLCHAIN_HAS_LIBATOMIC=y
+BR2_TOOLCHAIN_HAS_ATOMIC=y
+
+#
+# System configuration
+#
+BR2_ROOTFS_SKELETON_DEFAULT=y
+# BR2_ROOTFS_SKELETON_CUSTOM is not set
+# BR2_ROOTFS_MERGED_USR is not set
+BR2_TARGET_GENERIC_HOSTNAME="buildroot"
+BR2_TARGET_GENERIC_ISSUE="Welcome to Buildroot"
+BR2_TARGET_GENERIC_PASSWD_MD5=y
+# BR2_TARGET_GENERIC_PASSWD_SHA256 is not set
+# BR2_TARGET_GENERIC_PASSWD_SHA512 is not set
+BR2_TARGET_GENERIC_PASSWD_METHOD="md5"
+BR2_INIT_BUSYBOX=y
+# BR2_INIT_SYSV is not set
+# BR2_INIT_SYSTEMD is not set
+# BR2_INIT_NONE is not set
+# BR2_ROOTFS_DEVICE_CREATION_STATIC is not set
+BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_DEVTMPFS=y
+# BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_MDEV is not set
+# BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV is not set
+BR2_ROOTFS_DEVICE_TABLE="system/device_table.txt"
+# BR2_ROOTFS_DEVICE_TABLE_SUPPORTS_EXTENDED_ATTRIBUTES is not set
+BR2_TARGET_ENABLE_ROOT_LOGIN=y
+BR2_TARGET_GENERIC_ROOT_PASSWD=""
+BR2_SYSTEM_BIN_SH_BUSYBOX=y
+
+#
+# bash, dash, mksh, zsh need BR2_PACKAGE_BUSYBOX_SHOW_OTHERS
+#
+# BR2_SYSTEM_BIN_SH_NONE is not set
+BR2_TARGET_GENERIC_GETTY=y
+BR2_TARGET_GENERIC_GETTY_PORT="console"
+BR2_TARGET_GENERIC_GETTY_BAUDRATE_KEEP=y
+# BR2_TARGET_GENERIC_GETTY_BAUDRATE_9600 is not set
+# BR2_TARGET_GENERIC_GETTY_BAUDRATE_19200 is not set
+# BR2_TARGET_GENERIC_GETTY_BAUDRATE_38400 is not set
+# BR2_TARGET_GENERIC_GETTY_BAUDRATE_57600 is not set
+# BR2_TARGET_GENERIC_GETTY_BAUDRATE_115200 is not set
+BR2_TARGET_GENERIC_GETTY_BAUDRATE="0"
+BR2_TARGET_GENERIC_GETTY_TERM="vt100"
+BR2_TARGET_GENERIC_GETTY_OPTIONS=""
+BR2_TARGET_GENERIC_REMOUNT_ROOTFS_RW=y
+BR2_SYSTEM_DHCP=""
+BR2_ENABLE_LOCALE_PURGE=y
+BR2_ENABLE_LOCALE_WHITELIST="C en_US"
+BR2_GENERATE_LOCALE=""
+# BR2_SYSTEM_ENABLE_NLS is not set
+# BR2_TARGET_TZ_INFO is not set
+BR2_ROOTFS_USERS_TABLES=""
+BR2_ROOTFS_OVERLAY=""
+BR2_ROOTFS_POST_BUILD_SCRIPT=""
+BR2_ROOTFS_POST_FAKEROOT_SCRIPT=""
+BR2_ROOTFS_POST_IMAGE_SCRIPT=""
+
+#
+# Kernel
+#
+# BR2_LINUX_KERNEL is not set
+
+#
+# Target packages
+#
+BR2_PACKAGE_BUSYBOX=y
+BR2_PACKAGE_BUSYBOX_CONFIG="package/busybox/busybox.config"
+BR2_PACKAGE_BUSYBOX_CONFIG_FRAGMENT_FILES=""
+# BR2_PACKAGE_BUSYBOX_SHOW_OTHERS is not set
+# BR2_PACKAGE_BUSYBOX_SELINUX is not set
+# BR2_PACKAGE_BUSYBOX_INDIVIDUAL_BINARIES is not set
+# BR2_PACKAGE_BUSYBOX_WATCHDOG is not set
+BR2_PACKAGE_SKELETON=y
+BR2_PACKAGE_HAS_SKELETON=y
+BR2_PACKAGE_PROVIDES_SKELETON="skeleton-init-sysv"
+BR2_PACKAGE_SKELETON_INIT_COMMON=y
+BR2_PACKAGE_SKELETON_INIT_SYSV=y
+
+#
+# Audio and video applications
+#
+# BR2_PACKAGE_ALSA_UTILS is not set
+# BR2_PACKAGE_ATEST is not set
+# BR2_PACKAGE_AUMIX is not set
+# BR2_PACKAGE_BELLAGIO is not set
+# BR2_PACKAGE_DVBLAST is not set
+# BR2_PACKAGE_DVDAUTHOR is not set
+# BR2_PACKAGE_DVDRW_TOOLS is not set
+# BR2_PACKAGE_ESPEAK is not set
+# BR2_PACKAGE_FAAD2 is not set
+BR2_PACKAGE_FFMPEG_ARCH_SUPPORTS=y
+# BR2_PACKAGE_FFMPEG is not set
+# BR2_PACKAGE_FLAC is not set
+# BR2_PACKAGE_FLITE is not set
+# BR2_PACKAGE_GMRENDER_RESURRECT is not set
+# BR2_PACKAGE_GSTREAMER is not set
+# BR2_PACKAGE_GSTREAMER1 is not set
+# BR2_PACKAGE_JACK2 is not set
+BR2_PACKAGE_KODI_ARCH_SUPPORTS=y
+
+#
+# kodi needs python w/ .py modules, a uClibc or glibc toolchain w/ C++, locale, threads, wchar, dynamic library, gcc >= 4.8, host gcc >= 4.6
+#
+
+#
+# kodi needs an OpenGL EGL with either an openGL or an OpenGL ES backend
+#
+# BR2_PACKAGE_LAME is not set
+# BR2_PACKAGE_MADPLAY is not set
+# BR2_PACKAGE_MIMIC is not set
+
+#
+# miraclecast needs systemd and a glibc toolchain w/ threads and wchar
+#
+# BR2_PACKAGE_MJPEGTOOLS is not set
+# BR2_PACKAGE_MODPLUGTOOLS is not set
+# BR2_PACKAGE_MOTION is not set
+# BR2_PACKAGE_MPD is not set
+# BR2_PACKAGE_MPD_MPC is not set
+# BR2_PACKAGE_MPG123 is not set
+BR2_PACKAGE_MPLAYER_ARCH_SUPPORTS=y
+# BR2_PACKAGE_MPLAYER is not set
+# BR2_PACKAGE_MPV is not set
+# BR2_PACKAGE_MULTICAT is not set
+# BR2_PACKAGE_MUSEPACK is not set
+# BR2_PACKAGE_NCMPC is not set
+# BR2_PACKAGE_OPUS_TOOLS is not set
+BR2_PACKAGE_PULSEAUDIO_HAS_ATOMIC=y
+# BR2_PACKAGE_PULSEAUDIO is not set
+# BR2_PACKAGE_SOX is not set
+# BR2_PACKAGE_SQUEEZELITE is not set
+
+#
+# tovid depends on python or python3
+#
+# BR2_PACKAGE_TSTOOLS is not set
+# BR2_PACKAGE_TWOLAME is not set
+# BR2_PACKAGE_UDPXY is not set
+# BR2_PACKAGE_UPMPDCLI is not set
+# BR2_PACKAGE_V4L2GRAB is not set
+
+#
+# v4l2loopback needs a Linux kernel to be built
+#
+# BR2_PACKAGE_VLC is not set
+# BR2_PACKAGE_VORBIS_TOOLS is not set
+# BR2_PACKAGE_WAVPACK is not set
+# BR2_PACKAGE_YAVTA is not set
+# BR2_PACKAGE_YMPD is not set
+
+#
+# Compressors and decompressors
+#
+# BR2_PACKAGE_BZIP2 is not set
+# BR2_PACKAGE_LZ4 is not set
+# BR2_PACKAGE_LZIP is not set
+# BR2_PACKAGE_LZOP is not set
+# BR2_PACKAGE_P7ZIP is not set
+# BR2_PACKAGE_PIXZ is not set
+# BR2_PACKAGE_UNRAR is not set
+BR2_PACKAGE_XZ=y
+# BR2_PACKAGE_ZIP is not set
+# BR2_PACKAGE_ZSTD is not set
+
+#
+# Debugging, profiling and benchmark
+#
+# BR2_PACKAGE_BLKTRACE is not set
+# BR2_PACKAGE_BONNIE is not set
+# BR2_PACKAGE_CACHE_CALIBRATOR is not set
+# BR2_PACKAGE_DHRYSTONE is not set
+# BR2_PACKAGE_DIEHARDER is not set
+# BR2_PACKAGE_DMALLOC is not set
+# BR2_PACKAGE_DROPWATCH is not set
+# BR2_PACKAGE_DSTAT is not set
+# BR2_PACKAGE_DT is not set
+# BR2_PACKAGE_DUMA is not set
+# BR2_PACKAGE_FIO is not set
+BR2_PACKAGE_GDB_ARCH_SUPPORTS=y
+# BR2_PACKAGE_GDB is not set
+BR2_PACKAGE_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
+
+#
+# google-breakpad requires a glibc or uClibc toolchain w/ wchar, thread, C++, gcc >= 4.8
+#
+# BR2_PACKAGE_IOZONE is not set
+# BR2_PACKAGE_KEXEC is not set
+
+#
+# ktap needs a Linux kernel to be built
+#
+# BR2_PACKAGE_LATENCYTOP is not set
+# BR2_PACKAGE_LMBENCH is not set
+BR2_PACKAGE_LTP_TESTSUITE_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LTP_TESTSUITE is not set
+# BR2_PACKAGE_LTRACE is not set
+# BR2_PACKAGE_LTTNG_BABELTRACE is not set
+
+#
+# lttng-modules needs a Linux kernel to be built
+#
+# BR2_PACKAGE_LTTNG_TOOLS is not set
+# BR2_PACKAGE_MEMSTAT is not set
+# BR2_PACKAGE_NETPERF is not set
+# BR2_PACKAGE_NETSNIFF_NG is not set
+# BR2_PACKAGE_NMON is not set
+BR2_PACKAGE_OPROFILE_ARCH_SUPPORTS=y
+# BR2_PACKAGE_OPROFILE is not set
+# BR2_PACKAGE_PAX_UTILS is not set
+# BR2_PACKAGE_PV is not set
+# BR2_PACKAGE_RAMSMP is not set
+# BR2_PACKAGE_RAMSPEED is not set
+
+#
+# rt-tests needs a uClibc or glibc toolchain w/ NPTL, headers >= 3.14, dynamic library
+#
+# BR2_PACKAGE_SPIDEV_TEST is not set
+# BR2_PACKAGE_STRACE is not set
+# BR2_PACKAGE_STRESS is not set
+# BR2_PACKAGE_STRESS_NG is not set
+# BR2_PACKAGE_TINYMEMBENCH is not set
+# BR2_PACKAGE_TRACE_CMD is not set
+BR2_PACKAGE_TRINITY_ARCH_SUPPORTS=y
+# BR2_PACKAGE_TRINITY is not set
+# BR2_PACKAGE_UCLIBC_NG_TEST is not set
+BR2_PACKAGE_VALGRIND_ARCH_SUPPORTS=y
+# BR2_PACKAGE_VALGRIND is not set
+# BR2_PACKAGE_WHETSTONE is not set
+
+#
+# Development tools
+#
+# BR2_PACKAGE_BINUTILS is not set
+# BR2_PACKAGE_BSDIFF is not set
+# BR2_PACKAGE_CHECK is not set
+BR2_PACKAGE_CMAKE_ARCH_SUPPORTS=y
+# BR2_PACKAGE_CMAKE_CTEST is not set
+# BR2_PACKAGE_CPPUNIT is not set
+# BR2_PACKAGE_CVS is not set
+# BR2_PACKAGE_CXXTEST is not set
+# BR2_PACKAGE_FLEX is not set
+# BR2_PACKAGE_GETTEXT is not set
+# BR2_PACKAGE_GIT is not set
+# BR2_PACKAGE_GIT_CRYPT is not set
+# BR2_PACKAGE_GPERF is not set
+# BR2_PACKAGE_JO is not set
+# BR2_PACKAGE_JQ is not set
+# BR2_PACKAGE_LIBTOOL is not set
+# BR2_PACKAGE_MAKE is not set
+# BR2_PACKAGE_PKGCONF is not set
+# BR2_PACKAGE_SUBVERSION is not set
+BR2_PACKAGE_TREE=y
+
+#
+# Filesystem and flash utilities
+#
+
+#
+# aufs-util needs a linux kernel and a toolchain w/ threads
+#
+# BR2_PACKAGE_AUTOFS is not set
+# BR2_PACKAGE_BTRFS_PROGS is not set
+# BR2_PACKAGE_CIFS_UTILS is not set
+# BR2_PACKAGE_CPIO is not set
+# BR2_PACKAGE_CRAMFS is not set
+# BR2_PACKAGE_CURLFTPFS is not set
+# BR2_PACKAGE_DOSFSTOOLS is not set
+# BR2_PACKAGE_E2FSPROGS is not set
+# BR2_PACKAGE_E2TOOLS is not set
+# BR2_PACKAGE_ECRYPTFS_UTILS is not set
+# BR2_PACKAGE_EXFAT is not set
+# BR2_PACKAGE_EXFAT_UTILS is not set
+# BR2_PACKAGE_F2FS_TOOLS is not set
+# BR2_PACKAGE_FLASHBENCH is not set
+# BR2_PACKAGE_FSCRYPTCTL is not set
+# BR2_PACKAGE_FWUP is not set
+# BR2_PACKAGE_GENEXT2FS is not set
+# BR2_PACKAGE_GENPART is not set
+# BR2_PACKAGE_GENROMFS is not set
+# BR2_PACKAGE_MMC_UTILS is not set
+# BR2_PACKAGE_MTD is not set
+# BR2_PACKAGE_MTOOLS is not set
+# BR2_PACKAGE_NFS_UTILS is not set
+# BR2_PACKAGE_NTFS_3G is not set
+# BR2_PACKAGE_SP_OOPS_EXTRACT is not set
+BR2_PACKAGE_SQUASHFS=y
+BR2_PACKAGE_SQUASHFS_GZIP=y
+# BR2_PACKAGE_SQUASHFS_LZ4 is not set
+# BR2_PACKAGE_SQUASHFS_LZMA is not set
+# BR2_PACKAGE_SQUASHFS_LZO is not set
+BR2_PACKAGE_SQUASHFS_XZ=y
+# BR2_PACKAGE_SSHFS is not set
+# BR2_PACKAGE_SUNXI_TOOLS is not set
+# BR2_PACKAGE_UNIONFS is not set
+# BR2_PACKAGE_XFSPROGS is not set
+
+#
+# Fonts, cursors, icons, sounds and themes
+#
+
+#
+# Cursors
+#
+# BR2_PACKAGE_COMIX_CURSORS is not set
+# BR2_PACKAGE_OBSIDIAN_CURSORS is not set
+
+#
+# Fonts
+#
+# BR2_PACKAGE_BITSTREAM_VERA is not set
+# BR2_PACKAGE_CANTARELL is not set
+# BR2_PACKAGE_DEJAVU is not set
+# BR2_PACKAGE_FONT_AWESOME is not set
+# BR2_PACKAGE_GHOSTSCRIPT_FONTS is not set
+# BR2_PACKAGE_INCONSOLATA is not set
+# BR2_PACKAGE_LIBERATION is not set
+
+#
+# Icons
+#
+# BR2_PACKAGE_GOOGLE_MATERIAL_DESIGN_ICONS is not set
+# BR2_PACKAGE_HICOLOR_ICON_THEME is not set
+
+#
+# Sounds
+#
+# BR2_PACKAGE_SOUND_THEME_BOREALIS is not set
+# BR2_PACKAGE_SOUND_THEME_FREEDESKTOP is not set
+
+#
+# Themes
+#
+
+#
+# Games
+#
+# BR2_PACKAGE_CHOCOLATE_DOOM is not set
+# BR2_PACKAGE_GNUCHESS is not set
+# BR2_PACKAGE_LBREAKOUT2 is not set
+# BR2_PACKAGE_LTRIS is not set
+# BR2_PACKAGE_OPENTYRIAN is not set
+# BR2_PACKAGE_PRBOOM is not set
+# BR2_PACKAGE_SL is not set
+# BR2_PACKAGE_STELLA is not set
+
+#
+# Graphic libraries and applications (graphic/text)
+#
+
+#
+# Graphic applications
+#
+# BR2_PACKAGE_FSWEBCAM is not set
+# BR2_PACKAGE_GHOSTSCRIPT is not set
+
+#
+# glmark2 needs an OpenGL or an openGL ES and EGL backend provided by mesa3d
+#
+# BR2_PACKAGE_GNUPLOT is not set
+# BR2_PACKAGE_JHEAD is not set
+# BR2_PACKAGE_LIBVA_UTILS is not set
+# BR2_PACKAGE_PNGQUANT is not set
+# BR2_PACKAGE_RRDTOOL is not set
+# BR2_PACKAGE_TESSERACT_OCR is not set
+
+#
+# Graphic libraries
+#
+# BR2_PACKAGE_CEGUI06 is not set
+# BR2_PACKAGE_DIRECTFB is not set
+# BR2_PACKAGE_FBDUMP is not set
+# BR2_PACKAGE_FBGRAB is not set
+# BR2_PACKAGE_FB_TEST_APP is not set
+# BR2_PACKAGE_FBTERM is not set
+# BR2_PACKAGE_FBV is not set
+# BR2_PACKAGE_FREERDP is not set
+# BR2_PACKAGE_IMAGEMAGICK is not set
+
+#
+# linux-fusion needs a Linux kernel to be built
+#
+# BR2_PACKAGE_MESA3D is not set
+# BR2_PACKAGE_OCRAD is not set
+# BR2_PACKAGE_PSPLASH is not set
+BR2_PACKAGE_SDL=y
+BR2_PACKAGE_SDL_FBCON=y
+# BR2_PACKAGE_SDL_GFX is not set
+BR2_PACKAGE_SDL_IMAGE=y
+BR2_PACKAGE_SDL_IMAGE_BMP=y
+# BR2_PACKAGE_SDL_IMAGE_GIF is not set
+# BR2_PACKAGE_SDL_IMAGE_JPEG is not set
+# BR2_PACKAGE_SDL_IMAGE_LBM is not set
+# BR2_PACKAGE_SDL_IMAGE_PCX is not set
+BR2_PACKAGE_SDL_IMAGE_PNG=y
+# BR2_PACKAGE_SDL_IMAGE_PNM is not set
+# BR2_PACKAGE_SDL_IMAGE_TARGA is not set
+# BR2_PACKAGE_SDL_IMAGE_TIFF is not set
+# BR2_PACKAGE_SDL_IMAGE_WEBP is not set
+# BR2_PACKAGE_SDL_IMAGE_XCF is not set
+# BR2_PACKAGE_SDL_IMAGE_XPM is not set
+# BR2_PACKAGE_SDL_IMAGE_XV is not set
+# BR2_PACKAGE_SDL_MIXER is not set
+# BR2_PACKAGE_SDL_NET is not set
+# BR2_PACKAGE_SDL_SOUND is not set
+BR2_PACKAGE_SDL_TTF=y
+BR2_PACKAGE_SDL2=y
+
+#
+# DirectFB video driver needs directfb
+#
+
+#
+# X11 video driver needs X.org
+#
+BR2_PACKAGE_SDL2_KMSDRM=y
+
+#
+# OpenGL support needs X11 and an OpenGL provider
+#
+
+#
+# OpenGL ES support needs an OpenGL ES provider
+#
+# BR2_PACKAGE_SDL2_GFX is not set
+BR2_PACKAGE_SDL2_IMAGE=y
+# BR2_PACKAGE_SDL2_MIXER is not set
+# BR2_PACKAGE_SDL2_NET is not set
+BR2_PACKAGE_SDL2_TTF=y
+
+#
+# Other GUIs
+#
+# BR2_PACKAGE_QT is not set
+BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
+# BR2_PACKAGE_QT5 is not set
+
+#
+# tekui needs a Lua interpreter and a toolchain w/ threads, dynamic library
+#
+
+#
+# weston needs udev and a toolchain w/ locale, threads, dynamic library, headers >= 3.0
+#
+# BR2_PACKAGE_XORG7 is not set
+
+#
+# midori needs libgtk3 and a glibc toolchain w/ C++, gcc >= 5, host gcc >= 4.8
+#
+
+#
+# qt-webkit-kiosk needs a toolchain w/ dynamic library, gcc >= 4.8, host gcc >= 4.8
+#
+# BR2_PACKAGE_XKEYBOARD_CONFIG is not set
+
+#
+# Hardware handling
+#
+
+#
+# Firmware
+#
+# BR2_PACKAGE_AM33X_CM3 is not set
+# BR2_PACKAGE_B43_FIRMWARE is not set
+# BR2_PACKAGE_LINUX_FIRMWARE is not set
+# BR2_PACKAGE_RPI_BT_FIRMWARE is not set
+# BR2_PACKAGE_RPI_FIRMWARE is not set
+# BR2_PACKAGE_RPI_WIFI_FIRMWARE is not set
+# BR2_PACKAGE_SUNXI_BOARDS is not set
+# BR2_PACKAGE_TS4900_FPGA is not set
+# BR2_PACKAGE_UX500_FIRMWARE is not set
+# BR2_PACKAGE_WILC1000_FIRMWARE is not set
+# BR2_PACKAGE_WILINK_BT_FIRMWARE is not set
+# BR2_PACKAGE_ZD1211_FIRMWARE is not set
+
+#
+# a10disp needs a Linux kernel to be built
+#
+# BR2_PACKAGE_ACPICA is not set
+# BR2_PACKAGE_ACPITOOL is not set
+# BR2_PACKAGE_AER_INJECT is not set
+# BR2_PACKAGE_AM335X_PRU_PACKAGE is not set
+# BR2_PACKAGE_AVRDUDE is not set
+
+#
+# bcache-tools needs udev /dev management
+#
+# BR2_PACKAGE_CBOOTIMAGE is not set
+# BR2_PACKAGE_CC_TOOL is not set
+# BR2_PACKAGE_CDRKIT is not set
+# BR2_PACKAGE_CRYPTSETUP is not set
+# BR2_PACKAGE_CWIID is not set
+
+#
+# dahdi-linux needs a Linux kernel to be built
+#
+
+#
+# dahdi-tools needs a toolchain w/ threads
+#
+
+#
+# dahdi-tools needs a Linux kernel to be built
+#
+# BR2_PACKAGE_DBUS is not set
+# BR2_PACKAGE_DFU_UTIL is not set
+# BR2_PACKAGE_DMRAID is not set
+
+#
+# dt-utils needs udev /dev management
+#
+# BR2_PACKAGE_DTV_SCAN_TABLES is not set
+# BR2_PACKAGE_DUMP1090 is not set
+# BR2_PACKAGE_DVB_APPS is not set
+# BR2_PACKAGE_DVBSNOOP is not set
+# BR2_PACKAGE_EDID_DECODE is not set
+# BR2_PACKAGE_EEPROG is not set
+
+#
+# eudev needs eudev /dev management
+#
+# BR2_PACKAGE_EVEMU is not set
+BR2_PACKAGE_EVTEST=y
+# BR2_PACKAGE_FAN_CTRL is not set
+# BR2_PACKAGE_FCONFIG is not set
+# BR2_PACKAGE_FIS is not set
+# BR2_PACKAGE_FMTOOLS is not set
+# BR2_PACKAGE_FREESCALE_IMX is not set
+# BR2_PACKAGE_FXLOAD is not set
+# BR2_PACKAGE_GADGETFS_TEST is not set
+# BR2_PACKAGE_GPM is not set
+# BR2_PACKAGE_GPSD is not set
+# BR2_PACKAGE_GPTFDISK is not set
+# BR2_PACKAGE_GVFS is not set
+# BR2_PACKAGE_HWDATA is not set
+# BR2_PACKAGE_HWLOC is not set
+# BR2_PACKAGE_INPUT_EVENT_DAEMON is not set
+# BR2_PACKAGE_IOSTAT is not set
+# BR2_PACKAGE_IPMITOOL is not set
+
+#
+# iqvlinux needs a Linux kernel to be built
+#
+# BR2_PACKAGE_IRDA_UTILS is not set
+# BR2_PACKAGE_KBD is not set
+# BR2_PACKAGE_LCDPROC is not set
+# BR2_PACKAGE_LIBUIO is not set
+# BR2_PACKAGE_LIBUMP is not set
+# BR2_PACKAGE_LINUXCONSOLETOOLS is not set
+
+#
+# linux-backports needs a Linux kernel to be built
+#
+# BR2_PACKAGE_LIRC_TOOLS is not set
+# BR2_PACKAGE_LM_SENSORS is not set
+# BR2_PACKAGE_LSHW is not set
+# BR2_PACKAGE_LSSCSI is not set
+# BR2_PACKAGE_LSUIO is not set
+# BR2_PACKAGE_LUKSMETA is not set
+# BR2_PACKAGE_LVM2 is not set
+# BR2_PACKAGE_MALI_T76X is not set
+# BR2_PACKAGE_MDADM is not set
+# BR2_PACKAGE_MEMTESTER is not set
+# BR2_PACKAGE_MEMTOOL is not set
+# BR2_PACKAGE_MINICOM is not set
+# BR2_PACKAGE_NANOCOM is not set
+# BR2_PACKAGE_NEARD is not set
+
+#
+# nvidia-tegra23 needs Xorg <= 1.14 and a glibc toolchain w/ EABIhf
+#
+# BR2_PACKAGE_NVME is not set
+# BR2_PACKAGE_ODROID_MALI is not set
+# BR2_PACKAGE_ODROID_SCRIPTS is not set
+# BR2_PACKAGE_OFONO is not set
+# BR2_PACKAGE_OPEN2300 is not set
+# BR2_PACKAGE_OPENIPMI is not set
+# BR2_PACKAGE_OPENOCD is not set
+
+#
+# owl-linux needs a Linux kernel to be built
+#
+
+#
+# owl-linux is only supported on ARM9 architecture
+#
+# BR2_PACKAGE_PARTED is not set
+# BR2_PACKAGE_PCIUTILS is not set
+# BR2_PACKAGE_PDBG is not set
+# BR2_PACKAGE_PICOCOM is not set
+# BR2_PACKAGE_PIFMRDS is not set
+# BR2_PACKAGE_POWERTOP is not set
+# BR2_PACKAGE_PPS_TOOLS is not set
+# BR2_PACKAGE_READ_EDID is not set
+# BR2_PACKAGE_RNG_TOOLS is not set
+# BR2_PACKAGE_RPI_USERLAND is not set
+# BR2_PACKAGE_RS485CONF is not set
+
+#
+# rtl8188eu needs a Linux kernel to be built
+#
+
+#
+# rtl8723bs needs a Linux kernel to be built
+#
+
+#
+# rtl8821au needs a Linux kernel to be built
+#
+# BR2_PACKAGE_SANE_BACKENDS is not set
+# BR2_PACKAGE_SDPARM is not set
+# BR2_PACKAGE_SETSERIAL is not set
+# BR2_PACKAGE_SG3_UTILS is not set
+# BR2_PACKAGE_SIGROK_CLI is not set
+# BR2_PACKAGE_SISPMCTL is not set
+# BR2_PACKAGE_SMARTMONTOOLS is not set
+# BR2_PACKAGE_SMSTOOLS3 is not set
+# BR2_PACKAGE_SPI_TOOLS is not set
+# BR2_PACKAGE_SREDIRD is not set
+# BR2_PACKAGE_STATSERIAL is not set
+# BR2_PACKAGE_STM32FLASH is not set
+# BR2_PACKAGE_SUNXI_CEDARX is not set
+# BR2_PACKAGE_SUNXI_MALI is not set
+# BR2_PACKAGE_SYSSTAT is not set
+
+#
+# targetcli-fb depends on Python
+#
+
+#
+# ti-gfx needs a glibc toolchain and a Linux kernel to be built
+#
+
+#
+# ti-sgx-km needs a Linux kernel to be built
+#
+
+#
+# ti-sgx-um needs the ti-sgx-km driver
+#
+# BR2_PACKAGE_TI_UIM is not set
+# BR2_PACKAGE_TI_UTILS is not set
+# BR2_PACKAGE_TRIGGERHAPPY is not set
+# BR2_PACKAGE_UBOOT_TOOLS is not set
+# BR2_PACKAGE_UBUS is not set
+
+#
+# uccp420wlan needs a Linux kernel >= 4.2 to be built
+#
+
+#
+# udisks needs udev /dev management
+#
+# BR2_PACKAGE_UHUBCTL is not set
+
+#
+# upower needs udev /dev management
+#
+# BR2_PACKAGE_USB_MODESWITCH is not set
+# BR2_PACKAGE_USB_MODESWITCH_DATA is not set
+
+#
+# usbmount requires udev to be enabled
+#
+
+#
+# usbutils needs udev /dev management and toolchain w/ threads
+#
+# BR2_PACKAGE_W_SCAN is not set
+# BR2_PACKAGE_WIPE is not set
+# BR2_PACKAGE_XORRISO is not set
+
+#
+# xr819-xradio driver needs a Linux kernel to be built
+#
+
+#
+# Interpreter languages and scripting
+#
+# BR2_PACKAGE_4TH is not set
+# BR2_PACKAGE_ENSCRIPT is not set
+BR2_PACKAGE_ERLANG_ARCH_SUPPORTS=y
+# BR2_PACKAGE_ERLANG is not set
+# BR2_PACKAGE_EXECLINE is not set
+# BR2_PACKAGE_FICL is not set
+BR2_PACKAGE_GAUCHE_ARCH_SUPPORTS=y
+# BR2_PACKAGE_GAUCHE is not set
+# BR2_PACKAGE_GUILE is not set
+# BR2_PACKAGE_HASERL is not set
+# BR2_PACKAGE_JAMVM is not set
+# BR2_PACKAGE_JIMTCL is not set
+# BR2_PACKAGE_LUA is not set
+# BR2_PACKAGE_MICROPYTHON is not set
+# BR2_PACKAGE_MOARVM is not set
+BR2_PACKAGE_MONO_ARCH_SUPPORTS=y
+# BR2_PACKAGE_MONO is not set
+BR2_PACKAGE_NODEJS_ARCH_SUPPORTS=y
+
+#
+# nodejs needs a toolchain w/ C++, dynamic library, NPTL, gcc >= 4.8, wchar
+#
+# BR2_PACKAGE_PERL is not set
+# BR2_PACKAGE_PHP is not set
+# BR2_PACKAGE_PYTHON is not set
+# BR2_PACKAGE_PYTHON3 is not set
+# BR2_PACKAGE_RUBY is not set
+# BR2_PACKAGE_TCL is not set
+
+#
+# Libraries
+#
+
+#
+# Audio/Sound
+#
+BR2_PACKAGE_ALSA_LIB=y
+BR2_PACKAGE_ALSA_LIB_DEVDIR="/dev/snd"
+BR2_PACKAGE_ALSA_LIB_PCM_PLUGINS="all"
+BR2_PACKAGE_ALSA_LIB_CTL_PLUGINS="all"
+BR2_PACKAGE_ALSA_LIB_ALOAD=y
+BR2_PACKAGE_ALSA_LIB_MIXER=y
+BR2_PACKAGE_ALSA_LIB_PCM=y
+BR2_PACKAGE_ALSA_LIB_RAWMIDI=y
+BR2_PACKAGE_ALSA_LIB_HWDEP=y
+BR2_PACKAGE_ALSA_LIB_SEQ=y
+BR2_PACKAGE_ALSA_LIB_ALISP=y
+BR2_PACKAGE_ALSA_LIB_OLD_SYMBOLS=y
+# BR2_PACKAGE_AUBIO is not set
+# BR2_PACKAGE_AUDIOFILE is not set
+# BR2_PACKAGE_BCG729 is not set
+# BR2_PACKAGE_CELT051 is not set
+BR2_PACKAGE_FDK_AAC_ARCH_SUPPORTS=y
+# BR2_PACKAGE_FDK_AAC is not set
+# BR2_PACKAGE_LIBAO is not set
+# BR2_PACKAGE_LIBASPLIB is not set
+# BR2_PACKAGE_LIBBROADVOICE is not set
+# BR2_PACKAGE_LIBCDAUDIO is not set
+# BR2_PACKAGE_LIBCDDB is not set
+# BR2_PACKAGE_LIBCDIO is not set
+# BR2_PACKAGE_LIBCODEC2 is not set
+# BR2_PACKAGE_LIBCUE is not set
+# BR2_PACKAGE_LIBCUEFILE is not set
+# BR2_PACKAGE_LIBEBUR128 is not set
+# BR2_PACKAGE_LIBG7221 is not set
+# BR2_PACKAGE_LIBGSM is not set
+# BR2_PACKAGE_LIBID3TAG is not set
+# BR2_PACKAGE_LIBILBC is not set
+# BR2_PACKAGE_LIBLO is not set
+# BR2_PACKAGE_LIBMAD is not set
+# BR2_PACKAGE_LIBMODPLUG is not set
+# BR2_PACKAGE_LIBMPD is not set
+# BR2_PACKAGE_LIBMPDCLIENT is not set
+# BR2_PACKAGE_LIBREPLAYGAIN is not set
+# BR2_PACKAGE_LIBSAMPLERATE is not set
+# BR2_PACKAGE_LIBSIDPLAY2 is not set
+# BR2_PACKAGE_LIBSILK is not set
+# BR2_PACKAGE_LIBSNDFILE is not set
+# BR2_PACKAGE_LIBSOUNDTOUCH is not set
+# BR2_PACKAGE_LIBSOXR is not set
+# BR2_PACKAGE_LIBVORBIS is not set
+# BR2_PACKAGE_MP4V2 is not set
+BR2_PACKAGE_OPENAL_ARCH_SUPPORTS=y
+# BR2_PACKAGE_OPENAL is not set
+# BR2_PACKAGE_OPENCORE_AMR is not set
+# BR2_PACKAGE_OPUS is not set
+# BR2_PACKAGE_OPUSFILE is not set
+# BR2_PACKAGE_PORTAUDIO is not set
+# BR2_PACKAGE_SBC is not set
+# BR2_PACKAGE_SPEEX is not set
+# BR2_PACKAGE_TAGLIB is not set
+# BR2_PACKAGE_TINYALSA is not set
+# BR2_PACKAGE_TREMOR is not set
+# BR2_PACKAGE_VO_AACENC is not set
+BR2_PACKAGE_WEBRTC_AUDIO_PROCESSING_ARCH_SUPPORTS=y
+# BR2_PACKAGE_WEBRTC_AUDIO_PROCESSING is not set
+
+#
+# Compression and decompression
+#
+# BR2_PACKAGE_LIBARCHIVE is not set
+# BR2_PACKAGE_LIBSQUISH is not set
+# BR2_PACKAGE_LIBZIP is not set
+# BR2_PACKAGE_LZO is not set
+# BR2_PACKAGE_MINIZIP is not set
+# BR2_PACKAGE_SNAPPY is not set
+# BR2_PACKAGE_SZIP is not set
+BR2_PACKAGE_ZLIB=y
+
+#
+# Crypto
+#
+# BR2_PACKAGE_BEECRYPT is not set
+BR2_PACKAGE_BOTAN_ARCH_SUPPORTS=y
+# BR2_PACKAGE_BOTAN is not set
+# BR2_PACKAGE_CA_CERTIFICATES is not set
+
+#
+# cryptodev needs a Linux kernel to be built
+#
+# BR2_PACKAGE_GCR is not set
+# BR2_PACKAGE_GNUTLS is not set
+# BR2_PACKAGE_LIBASSUAN is not set
+# BR2_PACKAGE_LIBGCRYPT is not set
+BR2_PACKAGE_LIBGPG_ERROR_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LIBGPG_ERROR is not set
+BR2_PACKAGE_LIBGPG_ERROR_SYSCFG="arm-unknown-linux-gnueabi"
+# BR2_PACKAGE_LIBGPGME is not set
+# BR2_PACKAGE_LIBKCAPI is not set
+# BR2_PACKAGE_LIBKSBA is not set
+# BR2_PACKAGE_LIBMCRYPT is not set
+# BR2_PACKAGE_LIBMHASH is not set
+# BR2_PACKAGE_LIBNSS is not set
+# BR2_PACKAGE_LIBSCRYPT is not set
+# BR2_PACKAGE_LIBSECRET is not set
+# BR2_PACKAGE_LIBSHA1 is not set
+# BR2_PACKAGE_LIBSODIUM is not set
+# BR2_PACKAGE_LIBSSH is not set
+# BR2_PACKAGE_LIBSSH2 is not set
+# BR2_PACKAGE_LIBTOMCRYPT is not set
+# BR2_PACKAGE_LIBUECC is not set
+# BR2_PACKAGE_MBEDTLS is not set
+# BR2_PACKAGE_NETTLE is not set
+# BR2_PACKAGE_OPENSSL is not set
+BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
+# BR2_PACKAGE_RHASH is not set
+# BR2_PACKAGE_TINYDTLS is not set
+# BR2_PACKAGE_TROUSERS is not set
+# BR2_PACKAGE_USTREAM_SSL is not set
+
+#
+# Database
+#
+# BR2_PACKAGE_BERKELEYDB is not set
+# BR2_PACKAGE_GDBM is not set
+# BR2_PACKAGE_HIREDIS is not set
+# BR2_PACKAGE_KOMPEXSQLITE is not set
+# BR2_PACKAGE_LEVELDB is not set
+BR2_PACKAGE_MONGODB_ARCH_SUPPORTS=y
+# BR2_PACKAGE_MONGODB is not set
+# BR2_PACKAGE_MYSQL is not set
+# BR2_PACKAGE_POSTGRESQL is not set
+# BR2_PACKAGE_REDIS is not set
+# BR2_PACKAGE_SQLCIPHER is not set
+# BR2_PACKAGE_SQLITE is not set
+# BR2_PACKAGE_UNIXODBC is not set
+
+#
+# Filesystem
+#
+# BR2_PACKAGE_GAMIN is not set
+# BR2_PACKAGE_LIBCONFIG is not set
+# BR2_PACKAGE_LIBCONFUSE is not set
+# BR2_PACKAGE_LIBFUSE is not set
+# BR2_PACKAGE_LIBLOCKFILE is not set
+# BR2_PACKAGE_LIBNFS is not set
+# BR2_PACKAGE_LIBSYSFS is not set
+# BR2_PACKAGE_LOCKDEV is not set
+# BR2_PACKAGE_PHYSFS is not set
+
+#
+# Graphics
+#
+# BR2_PACKAGE_ASSIMP is not set
+# BR2_PACKAGE_ATK is not set
+# BR2_PACKAGE_ATKMM is not set
+# BR2_PACKAGE_BULLET is not set
+# BR2_PACKAGE_CAIRO is not set
+# BR2_PACKAGE_CAIROMM is not set
+# BR2_PACKAGE_EXIV2 is not set
+# BR2_PACKAGE_FONTCONFIG is not set
+BR2_PACKAGE_FREETYPE=y
+# BR2_PACKAGE_GD is not set
+# BR2_PACKAGE_GDK_PIXBUF is not set
+# BR2_PACKAGE_GIFLIB is not set
+
+#
+# granite needs libgtk3 and a toolchain w/ wchar, threads
+#
+# BR2_PACKAGE_GRAPHITE2 is not set
+
+#
+# gtkmm3 needs libgtk3 and a toolchain w/ C++, wchar, threads, gcc >= 4.9
+#
+# BR2_PACKAGE_HARFBUZZ is not set
+# BR2_PACKAGE_IJS is not set
+# BR2_PACKAGE_IMLIB2 is not set
+
+#
+# irrlicht needs X11 and an OpenGL provider
+#
+# BR2_PACKAGE_JASPER is not set
+BR2_PACKAGE_JPEG=y
+BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
+BR2_PACKAGE_LIBJPEG=y
+# BR2_PACKAGE_JPEG_TURBO is not set
+BR2_PACKAGE_HAS_JPEG=y
+BR2_PACKAGE_PROVIDES_JPEG="libjpeg"
+# BR2_PACKAGE_KMSXX is not set
+# BR2_PACKAGE_LCMS2 is not set
+# BR2_PACKAGE_LENSFUN is not set
+# BR2_PACKAGE_LEPTONICA is not set
+# BR2_PACKAGE_LIBART is not set
+# BR2_PACKAGE_LIBDMTX is not set
+BR2_PACKAGE_LIBDRM=y
+BR2_PACKAGE_LIBDRM_HAS_ATOMIC=y
+# BR2_PACKAGE_LIBDRM_RADEON is not set
+# BR2_PACKAGE_LIBDRM_AMDGPU is not set
+# BR2_PACKAGE_LIBDRM_NOUVEAU is not set
+# BR2_PACKAGE_LIBDRM_OMAP is not set
+# BR2_PACKAGE_LIBDRM_ETNAVIV is not set
+# BR2_PACKAGE_LIBDRM_EXYNOS is not set
+# BR2_PACKAGE_LIBDRM_FREEDRENO is not set
+# BR2_PACKAGE_LIBDRM_TEGRA is not set
+# BR2_PACKAGE_LIBDRM_VC4 is not set
+# BR2_PACKAGE_LIBDRM_INSTALL_TESTS is not set
+
+#
+# libepoxy needs an OpenGL and/or OpenGL EGL backend
+#
+# BR2_PACKAGE_LIBEXIF is not set
+
+#
+# libfm needs X.org and a toolchain w/ wchar, threads, C++
+#
+# BR2_PACKAGE_LIBFM_EXTRA is not set
+
+#
+# libfreeglut depends on X.org and needs an OpenGL backend
+#
+# BR2_PACKAGE_LIBFREEIMAGE is not set
+# BR2_PACKAGE_LIBGEOTIFF is not set
+
+#
+# libglew depends on X.org and needs an OpenGL backend
+#
+
+#
+# libglfw depends on X.org and needs an OpenGL backend
+#
+
+#
+# libglu needs an OpenGL backend
+#
+
+#
+# libgtk3 needs an OpenGL or an OpenGL-EGL/wayland backend
+#
+# BR2_PACKAGE_LIBMEDIAART is not set
+# BR2_PACKAGE_LIBMNG is not set
+BR2_PACKAGE_LIBPNG=y
+# BR2_PACKAGE_LIBQRENCODE is not set
+# BR2_PACKAGE_LIBRAW is not set
+# BR2_PACKAGE_LIBRSVG is not set
+
+#
+# libsoil needs an OpenGL backend and a toolchain w/ dynamic library
+#
+# BR2_PACKAGE_LIBSVG is not set
+# BR2_PACKAGE_LIBSVG_CAIRO is not set
+# BR2_PACKAGE_LIBSVGTINY is not set
+# BR2_PACKAGE_LIBVA is not set
+# BR2_PACKAGE_LIBVIPS is not set
+# BR2_PACKAGE_MENU_CACHE is not set
+# BR2_PACKAGE_OPENCV is not set
+# BR2_PACKAGE_OPENCV3 is not set
+# BR2_PACKAGE_OPENJPEG is not set
+# BR2_PACKAGE_PANGO is not set
+# BR2_PACKAGE_PANGOMM is not set
+# BR2_PACKAGE_PIXMAN is not set
+# BR2_PACKAGE_POPPLER is not set
+# BR2_PACKAGE_TIFF is not set
+# BR2_PACKAGE_WAYLAND is not set
+BR2_PACKAGE_WEBKITGTK_ARCH_SUPPORTS=y
+
+#
+# webkitgtk needs libgtk3 and a glibc toolchain w/ C++, gcc >= 5, host gcc >= 4.8
+#
+# BR2_PACKAGE_WEBP is not set
+# BR2_PACKAGE_ZBAR is not set
+# BR2_PACKAGE_ZXING_CPP is not set
+
+#
+# Hardware handling
+#
+# BR2_PACKAGE_ACSCCID is not set
+# BR2_PACKAGE_BCM2835 is not set
+# BR2_PACKAGE_C_PERIPHERY is not set
+# BR2_PACKAGE_CCID is not set
+# BR2_PACKAGE_DTC is not set
+# BR2_PACKAGE_GNU_EFI is not set
+
+#
+# hidapi needs udev /dev management and a toolchain w/ NPTL threads
+#
+# BR2_PACKAGE_LCDAPI is not set
+# BR2_PACKAGE_LET_ME_CREATE is not set
+BR2_PACKAGE_LIBAIO_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LIBAIO is not set
+
+#
+# libatasmart requires udev to be enabled
+#
+# BR2_PACKAGE_LIBCEC is not set
+# BR2_PACKAGE_LIBFREEFARE is not set
+# BR2_PACKAGE_LIBFTDI is not set
+# BR2_PACKAGE_LIBFTDI1 is not set
+# BR2_PACKAGE_LIBGPHOTO2 is not set
+
+#
+# libgpiod needs kernel headers >= 4.8
+#
+
+#
+# libgudev needs udev /dev handling and a toolchain w/ wchar, threads
+#
+# BR2_PACKAGE_LIBHID is not set
+# BR2_PACKAGE_LIBIIO is not set
+
+#
+# libinput needs udev /dev management and a toolchain w/ locale
+#
+# BR2_PACKAGE_LIBIQRF is not set
+# BR2_PACKAGE_LIBLLCP is not set
+# BR2_PACKAGE_LIBMBIM is not set
+# BR2_PACKAGE_LIBNFC is not set
+# BR2_PACKAGE_LIBPCIACCESS is not set
+# BR2_PACKAGE_LIBPHIDGET is not set
+
+#
+# libpri needs a kernel to be built
+#
+# BR2_PACKAGE_LIBQMI is not set
+# BR2_PACKAGE_LIBRAW1394 is not set
+# BR2_PACKAGE_LIBRTLSDR is not set
+# BR2_PACKAGE_LIBSERIAL is not set
+# BR2_PACKAGE_LIBSERIALPORT is not set
+# BR2_PACKAGE_LIBSIGROK is not set
+# BR2_PACKAGE_LIBSIGROKDECODE is not set
+# BR2_PACKAGE_LIBSOC is not set
+
+#
+# libss7 needs a kernel to be built
+#
+# BR2_PACKAGE_LIBUSB is not set
+# BR2_PACKAGE_LIBUSBGX is not set
+# BR2_PACKAGE_LIBV4L is not set
+# BR2_PACKAGE_LIBXKBCOMMON is not set
+# BR2_PACKAGE_MRAA is not set
+# BR2_PACKAGE_MTDEV is not set
+# BR2_PACKAGE_NE10 is not set
+# BR2_PACKAGE_NEARDAL is not set
+# BR2_PACKAGE_OWFS is not set
+# BR2_PACKAGE_PCSC_LITE is not set
+# BR2_PACKAGE_TSLIB is not set
+# BR2_PACKAGE_URG is not set
+# BR2_PACKAGE_WIRINGPI is not set
+
+#
+# Javascript
+#
+# BR2_PACKAGE_ANGULARJS is not set
+# BR2_PACKAGE_BOOTSTRAP is not set
+# BR2_PACKAGE_EXPLORERCANVAS is not set
+# BR2_PACKAGE_FLOT is not set
+# BR2_PACKAGE_JQUERY is not set
+# BR2_PACKAGE_JSMIN is not set
+# BR2_PACKAGE_JSON_JAVASCRIPT is not set
+
+#
+# JSON/XML
+#
+# BR2_PACKAGE_BENEJSON is not set
+# BR2_PACKAGE_CJSON is not set
+# BR2_PACKAGE_EXPAT is not set
+# BR2_PACKAGE_EZXML is not set
+# BR2_PACKAGE_JANSSON is not set
+# BR2_PACKAGE_JOSE is not set
+# BR2_PACKAGE_JSMN is not set
+# BR2_PACKAGE_JSON_C is not set
+# BR2_PACKAGE_JSON_GLIB is not set
+# BR2_PACKAGE_JSONCPP is not set
+# BR2_PACKAGE_LIBBSON is not set
+# BR2_PACKAGE_LIBFASTJSON is not set
+# BR2_PACKAGE_LIBJSON is not set
+# BR2_PACKAGE_LIBROXML is not set
+# BR2_PACKAGE_LIBUCL is not set
+# BR2_PACKAGE_LIBXML2 is not set
+# BR2_PACKAGE_LIBXMLPP is not set
+# BR2_PACKAGE_LIBXMLRPC is not set
+# BR2_PACKAGE_LIBXSLT is not set
+# BR2_PACKAGE_LIBYAML is not set
+# BR2_PACKAGE_MXML is not set
+# BR2_PACKAGE_PUGIXML is not set
+# BR2_PACKAGE_RAPIDJSON is not set
+# BR2_PACKAGE_RAPIDXML is not set
+# BR2_PACKAGE_RAPTOR is not set
+# BR2_PACKAGE_TINYXML is not set
+# BR2_PACKAGE_TINYXML2 is not set
+# BR2_PACKAGE_VALIJSON is not set
+# BR2_PACKAGE_XERCES is not set
+# BR2_PACKAGE_YAJL is not set
+# BR2_PACKAGE_YAML_CPP is not set
+
+#
+# Logging
+#
+# BR2_PACKAGE_EVENTLOG is not set
+# BR2_PACKAGE_GLOG is not set
+# BR2_PACKAGE_LIBLOG4C_LOCALTIME is not set
+# BR2_PACKAGE_LIBLOGGING is not set
+# BR2_PACKAGE_LOG4CPLUS is not set
+# BR2_PACKAGE_LOG4CPP is not set
+# BR2_PACKAGE_LOG4CXX is not set
+# BR2_PACKAGE_ZLOG is not set
+
+#
+# Multimedia
+#
+# BR2_PACKAGE_BITSTREAM is not set
+# BR2_PACKAGE_KVAZAAR is not set
+# BR2_PACKAGE_LIBAACS is not set
+# BR2_PACKAGE_LIBAMCODEC is not set
+# BR2_PACKAGE_LIBASS is not set
+# BR2_PACKAGE_LIBBDPLUS is not set
+# BR2_PACKAGE_LIBBLURAY is not set
+# BR2_PACKAGE_LIBDCADEC is not set
+# BR2_PACKAGE_LIBDVBCSA is not set
+# BR2_PACKAGE_LIBDVBPSI is not set
+# BR2_PACKAGE_LIBDVBSI is not set
+# BR2_PACKAGE_LIBDVDCSS is not set
+# BR2_PACKAGE_LIBDVDNAV is not set
+# BR2_PACKAGE_LIBDVDREAD is not set
+# BR2_PACKAGE_LIBEBML is not set
+# BR2_PACKAGE_LIBHDHOMERUN is not set
+
+#
+# libimxvpuapi needs an i.MX platform with VPU support
+#
+# BR2_PACKAGE_LIBMATROSKA is not set
+# BR2_PACKAGE_LIBMMS is not set
+# BR2_PACKAGE_LIBMPEG2 is not set
+# BR2_PACKAGE_LIBOGG is not set
+BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LIBOPENH264 is not set
+# BR2_PACKAGE_LIBPLAYER is not set
+# BR2_PACKAGE_LIBTHEORA is not set
+# BR2_PACKAGE_LIBVPX is not set
+# BR2_PACKAGE_LIBYUV is not set
+# BR2_PACKAGE_LIVE555 is not set
+# BR2_PACKAGE_MEDIASTREAMER is not set
+# BR2_PACKAGE_X264 is not set
+# BR2_PACKAGE_X265 is not set
+
+#
+# Networking
+#
+# BR2_PACKAGE_AGENTPP is not set
+# BR2_PACKAGE_ALLJOYN is not set
+# BR2_PACKAGE_ALLJOYN_BASE is not set
+# BR2_PACKAGE_ALLJOYN_TCL is not set
+# BR2_PACKAGE_ALLJOYN_TCL_BASE is not set
+# BR2_PACKAGE_AZMQ is not set
+# BR2_PACKAGE_AZURE_IOT_SDK_C is not set
+
+#
+# batman-adv needs a Linux kernel to be built
+#
+# BR2_PACKAGE_C_ARES is not set
+BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
+# BR2_PACKAGE_CANFESTIVAL is not set
+# BR2_PACKAGE_CGIC is not set
+# BR2_PACKAGE_CPPZMQ is not set
+# BR2_PACKAGE_CZMQ is not set
+# BR2_PACKAGE_FILEMQ is not set
+# BR2_PACKAGE_FLICKCURL is not set
+# BR2_PACKAGE_FREERADIUS_CLIENT is not set
+# BR2_PACKAGE_GEOIP is not set
+# BR2_PACKAGE_GLIB_NETWORKING is not set
+# BR2_PACKAGE_GSSDP is not set
+# BR2_PACKAGE_GUPNP is not set
+# BR2_PACKAGE_GUPNP_AV is not set
+# BR2_PACKAGE_GUPNP_DLNA is not set
+# BR2_PACKAGE_IBRCOMMON is not set
+# BR2_PACKAGE_IBRDTN is not set
+# BR2_PACKAGE_LIBCGI is not set
+# BR2_PACKAGE_LIBCGICC is not set
+# BR2_PACKAGE_LIBCOAP is not set
+# BR2_PACKAGE_LIBCURL is not set
+# BR2_PACKAGE_LIBDNET is not set
+# BR2_PACKAGE_LIBEXOSIP2 is not set
+# BR2_PACKAGE_LIBFCGI is not set
+# BR2_PACKAGE_LIBGSASL is not set
+# BR2_PACKAGE_LIBHTTPPARSER is not set
+# BR2_PACKAGE_LIBIDN is not set
+# BR2_PACKAGE_LIBISCSI is not set
+# BR2_PACKAGE_LIBLDNS is not set
+# BR2_PACKAGE_LIBMAXMINDDB is not set
+# BR2_PACKAGE_LIBMBUS is not set
+# BR2_PACKAGE_LIBMEMCACHED is not set
+# BR2_PACKAGE_LIBMICROHTTPD is not set
+# BR2_PACKAGE_LIBMINIUPNPC is not set
+# BR2_PACKAGE_LIBMNL is not set
+# BR2_PACKAGE_LIBMODBUS is not set
+# BR2_PACKAGE_LIBNATPMP is not set
+# BR2_PACKAGE_LIBNDP is not set
+# BR2_PACKAGE_LIBNET is not set
+# BR2_PACKAGE_LIBNETFILTER_ACCT is not set
+# BR2_PACKAGE_LIBNETFILTER_CONNTRACK is not set
+# BR2_PACKAGE_LIBNETFILTER_CTHELPER is not set
+# BR2_PACKAGE_LIBNETFILTER_CTTIMEOUT is not set
+# BR2_PACKAGE_LIBNETFILTER_LOG is not set
+# BR2_PACKAGE_LIBNETFILTER_QUEUE is not set
+# BR2_PACKAGE_LIBNFNETLINK is not set
+
+#
+# libnftnl needs a toolchain w/ headers >= 3.12
+#
+# BR2_PACKAGE_LIBNICE is not set
+# BR2_PACKAGE_LIBNL is not set
+# BR2_PACKAGE_LIBOAUTH is not set
+# BR2_PACKAGE_LIBOPING is not set
+# BR2_PACKAGE_LIBOSIP2 is not set
+# BR2_PACKAGE_LIBPCAP is not set
+# BR2_PACKAGE_LIBPJSIP is not set
+# BR2_PACKAGE_LIBRSYNC is not set
+# BR2_PACKAGE_LIBSHAIRPLAY is not set
+# BR2_PACKAGE_LIBSHOUT is not set
+# BR2_PACKAGE_LIBSOCKETCAN is not set
+# BR2_PACKAGE_LIBSOUP is not set
+# BR2_PACKAGE_LIBSRTP is not set
+# BR2_PACKAGE_LIBSTROPHE is not set
+# BR2_PACKAGE_LIBTIRPC is not set
+# BR2_PACKAGE_LIBTORRENT is not set
+# BR2_PACKAGE_LIBUPNP is not set
+# BR2_PACKAGE_LIBUPNPP is not set
+# BR2_PACKAGE_LIBURIPARSER is not set
+# BR2_PACKAGE_LIBVNCSERVER is not set
+# BR2_PACKAGE_LIBWEBSOCK is not set
+# BR2_PACKAGE_LIBWEBSOCKETS is not set
+# BR2_PACKAGE_LKSCTP_TOOLS is not set
+# BR2_PACKAGE_MONGOOSE is not set
+# BR2_PACKAGE_NANOMSG is not set
+# BR2_PACKAGE_NEON is not set
+# BR2_PACKAGE_NORM is not set
+# BR2_PACKAGE_NSS_PAM_LDAPD is not set
+# BR2_PACKAGE_OMNIORB is not set
+# BR2_PACKAGE_OPENLDAP is not set
+# BR2_PACKAGE_OPENMPI is not set
+# BR2_PACKAGE_OPENPGM is not set
+
+#
+# openzwave needs udev and a toolchain w/ C++, threads, wchar
+#
+# BR2_PACKAGE_ORTP is not set
+# BR2_PACKAGE_PAHO_MQTT_C is not set
+# BR2_PACKAGE_QDECODER is not set
+# BR2_PACKAGE_QPID_PROTON is not set
+# BR2_PACKAGE_RABBITMQ_C is not set
+# BR2_PACKAGE_RTMPDUMP is not set
+# BR2_PACKAGE_SLIRP is not set
+# BR2_PACKAGE_SNMPPP is not set
+# BR2_PACKAGE_SOFIA_SIP is not set
+# BR2_PACKAGE_THRIFT is not set
+# BR2_PACKAGE_USBREDIR is not set
+# BR2_PACKAGE_ZEROMQ is not set
+# BR2_PACKAGE_ZMQPP is not set
+# BR2_PACKAGE_ZYRE is not set
+
+#
+# Other
+#
+# BR2_PACKAGE_APR is not set
+# BR2_PACKAGE_APR_UTIL is not set
+# BR2_PACKAGE_ARMADILLO is not set
+# BR2_PACKAGE_ATF is not set
+# BR2_PACKAGE_BCTOOLBOX is not set
+# BR2_PACKAGE_BDWGC is not set
+# BR2_PACKAGE_BOOST is not set
+# BR2_PACKAGE_CLAPACK is not set
+BR2_PACKAGE_CLASSPATH_ARCH_SUPPORTS=y
+# BR2_PACKAGE_CLASSPATH is not set
+# BR2_PACKAGE_CPPCMS is not set
+# BR2_PACKAGE_CRACKLIB is not set
+# BR2_PACKAGE_DAWGDIC is not set
+# BR2_PACKAGE_DING_LIBS is not set
+# BR2_PACKAGE_EIGEN is not set
+# BR2_PACKAGE_ELFUTILS is not set
+# BR2_PACKAGE_FFTW is not set
+# BR2_PACKAGE_FLANN is not set
+# BR2_PACKAGE_GFLAGS is not set
+# BR2_PACKAGE_GLIBMM is not set
+# BR2_PACKAGE_GLM is not set
+# BR2_PACKAGE_GMP is not set
+# BR2_PACKAGE_GSL is not set
+# BR2_PACKAGE_GTEST is not set
+BR2_PACKAGE_JEMALLOC_ARCH_SUPPORTS=y
+# BR2_PACKAGE_JEMALLOC is not set
+
+#
+# lapack/blas needs a toolchain w/ fortran
+#
+# BR2_PACKAGE_LIBARGTABLE2 is not set
+BR2_PACKAGE_LIBATOMIC_OPS_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LIBATOMIC_OPS is not set
+# BR2_PACKAGE_LIBB64 is not set
+BR2_PACKAGE_LIBBSD_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LIBBSD is not set
+# BR2_PACKAGE_LIBCAP is not set
+# BR2_PACKAGE_LIBCAP_NG is not set
+# BR2_PACKAGE_LIBCGROUP is not set
+# BR2_PACKAGE_LIBCOFI is not set
+# BR2_PACKAGE_LIBCROCO is not set
+# BR2_PACKAGE_LIBCROSSGUID is not set
+# BR2_PACKAGE_LIBCSV is not set
+# BR2_PACKAGE_LIBDAEMON is not set
+# BR2_PACKAGE_LIBEE is not set
+# BR2_PACKAGE_LIBEV is not set
+# BR2_PACKAGE_LIBEVDEV is not set
+# BR2_PACKAGE_LIBEVENT is not set
+# BR2_PACKAGE_LIBFFI is not set
+# BR2_PACKAGE_LIBGEE is not set
+# BR2_PACKAGE_LIBGLIB2 is not set
+# BR2_PACKAGE_LIBGLOB is not set
+# BR2_PACKAGE_LIBICAL is not set
+# BR2_PACKAGE_LIBITE is not set
+# BR2_PACKAGE_LIBLINEAR is not set
+# BR2_PACKAGE_LIBLOKI is not set
+# BR2_PACKAGE_LIBNPTH is not set
+BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
+# BR2_PACKAGE_LIBNSPR is not set
+# BR2_PACKAGE_LIBPFM4 is not set
+# BR2_PACKAGE_LIBPLIST is not set
+BR2_PACKAGE_LIBPTHREAD_STUBS=y
+# BR2_PACKAGE_LIBPTHSEM is not set
+# BR2_PACKAGE_LIBPWQUALITY is not set
+BR2_PACKAGE_LIBSECCOMP_ARCH_SUPPORTS=y
+
+#
+# libseccomp needs a toolchain w/ headers >= 3.12
+#
+# BR2_PACKAGE_LIBSIGC is not set
+BR2_PACKAGE_LIBSIGSEGV_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LIBSIGSEGV is not set
+# BR2_PACKAGE_LIBSPATIALINDEX is not set
+# BR2_PACKAGE_LIBTASN1 is not set
+# BR2_PACKAGE_LIBTOMMATH is not set
+# BR2_PACKAGE_LIBTPL is not set
+# BR2_PACKAGE_LIBUBOX is not set
+# BR2_PACKAGE_LIBUCI is not set
+BR2_PACKAGE_LIBUNWIND_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LIBUNWIND is not set
+BR2_PACKAGE_LIBURCU_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LIBURCU is not set
+# BR2_PACKAGE_LIBUV is not set
+# BR2_PACKAGE_LIGHTNING is not set
+# BR2_PACKAGE_LINUX_PAM is not set
+# BR2_PACKAGE_LIQUID_DSP is not set
+# BR2_PACKAGE_LTTNG_LIBUST is not set
+# BR2_PACKAGE_MPC is not set
+# BR2_PACKAGE_MPDECIMAL is not set
+# BR2_PACKAGE_MPFR is not set
+# BR2_PACKAGE_MPIR is not set
+# BR2_PACKAGE_MSGPACK is not set
+# BR2_PACKAGE_MTDEV2TUIO is not set
+BR2_PACKAGE_OPENBLAS_DEFAULT_TARGET="CORTEXA9"
+BR2_PACKAGE_OPENBLAS_ARCH_SUPPORTS=y
+# BR2_PACKAGE_OPENBLAS is not set
+# BR2_PACKAGE_ORC is not set
+# BR2_PACKAGE_P11_KIT is not set
+# BR2_PACKAGE_POCO is not set
+# BR2_PACKAGE_QHULL is not set
+# BR2_PACKAGE_QLIBC is not set
+# BR2_PACKAGE_SHAPELIB is not set
+# BR2_PACKAGE_SKALIBS is not set
+# BR2_PACKAGE_SPHINXBASE is not set
+# BR2_PACKAGE_TINYCBOR is not set
+
+#
+# Security
+#
+# BR2_PACKAGE_LIBSELINUX is not set
+# BR2_PACKAGE_LIBSEMANAGE is not set
+# BR2_PACKAGE_LIBSEPOL is not set
+
+#
+# Text and terminal handling
+#
+# BR2_PACKAGE_AUGEAS is not set
+# BR2_PACKAGE_ENCHANT is not set
+# BR2_PACKAGE_FMT is not set
+
+#
+# icu needs a toolchain w/ C++, wchar, threads, gcc >= 4.8, host gcc >= 4.8
+#
+# BR2_PACKAGE_LIBCLI is not set
+# BR2_PACKAGE_LIBEDIT is not set
+# BR2_PACKAGE_LIBENCA is not set
+# BR2_PACKAGE_LIBESTR is not set
+# BR2_PACKAGE_LIBFRIBIDI is not set
+# BR2_PACKAGE_LIBUNISTRING is not set
+# BR2_PACKAGE_LINENOISE is not set
+# BR2_PACKAGE_NCURSES is not set
+# BR2_PACKAGE_NEWT is not set
+# BR2_PACKAGE_PCRE is not set
+# BR2_PACKAGE_PCRE2 is not set
+# BR2_PACKAGE_POPT is not set
+# BR2_PACKAGE_READLINE is not set
+# BR2_PACKAGE_SLANG is not set
+# BR2_PACKAGE_TCLAP is not set
+# BR2_PACKAGE_USTR is not set
+
+#
+# Mail
+#
+# BR2_PACKAGE_DOVECOT is not set
+# BR2_PACKAGE_EXIM is not set
+# BR2_PACKAGE_FETCHMAIL is not set
+# BR2_PACKAGE_HEIRLOOM_MAILX is not set
+# BR2_PACKAGE_LIBESMTP is not set
+# BR2_PACKAGE_MSMTP is not set
+# BR2_PACKAGE_MUTT is not set
+
+#
+# Miscellaneous
+#
+# BR2_PACKAGE_AESPIPE is not set
+# BR2_PACKAGE_BC is not set
+# BR2_PACKAGE_CLAMAV is not set
+# BR2_PACKAGE_COLLECTD is not set
+
+#
+# domoticz needs lua >= 5.2 and a toolchain w/ C++, threads, wchar, dynamic library
+#
+# BR2_PACKAGE_EMPTY is not set
+# BR2_PACKAGE_GNURADIO is not set
+# BR2_PACKAGE_GOOGLEFONTDIRECTORY is not set
+
+#
+# gqrx needs qt5, gnuradio, fftw's single precision
+#
+# BR2_PACKAGE_GSETTINGS_DESKTOP_SCHEMAS is not set
+# BR2_PACKAGE_HAVEGED is not set
+# BR2_PACKAGE_LINUX_SYSCALL_SUPPORT is not set
+# BR2_PACKAGE_MCRYPT is not set
+# BR2_PACKAGE_MOBILE_BROADBAND_PROVIDER_INFO is not set
+BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
+# BR2_PACKAGE_QEMU is not set
+# BR2_PACKAGE_QPDF is not set
+# BR2_PACKAGE_SHARED_MIME_INFO is not set
+# BR2_PACKAGE_TASKD is not set
+# BR2_PACKAGE_XUTIL_UTIL_MACROS is not set
+
+#
+# Networking applications
+#
+# BR2_PACKAGE_AIRCRACK_NG is not set
+# BR2_PACKAGE_APACHE is not set
+# BR2_PACKAGE_ARGUS is not set
+# BR2_PACKAGE_ARP_SCAN is not set
+# BR2_PACKAGE_ARPTABLES is not set
+# BR2_PACKAGE_ASTERISK is not set
+# BR2_PACKAGE_ATFTP is not set
+# BR2_PACKAGE_AVAHI is not set
+# BR2_PACKAGE_AXEL is not set
+# BR2_PACKAGE_BABELD is not set
+# BR2_PACKAGE_BANDWIDTHD is not set
+# BR2_PACKAGE_BATCTL is not set
+# BR2_PACKAGE_BCUSDK is not set
+# BR2_PACKAGE_BIND is not set
+# BR2_PACKAGE_BLUEZ_UTILS is not set
+# BR2_PACKAGE_BLUEZ5_UTILS is not set
+# BR2_PACKAGE_BMON is not set
+# BR2_PACKAGE_BOA is not set
+# BR2_PACKAGE_BOINC is not set
+# BR2_PACKAGE_BRIDGE_UTILS is not set
+# BR2_PACKAGE_BWM_NG is not set
+# BR2_PACKAGE_C_ICAP is not set
+# BR2_PACKAGE_CAN_UTILS is not set
+# BR2_PACKAGE_CANNELLONI is not set
+# BR2_PACKAGE_CHRONY is not set
+# BR2_PACKAGE_CIVETWEB is not set
+# BR2_PACKAGE_CONNMAN is not set
+
+#
+# connman-gtk needs libgtk3 and a glibc or uClibc toolchain w/ wchar, threads, resolver, dynamic library
+#
+# BR2_PACKAGE_CONNTRACK_TOOLS is not set
+# BR2_PACKAGE_CRDA is not set
+# BR2_PACKAGE_CTORRENT is not set
+# BR2_PACKAGE_CUPS is not set
+# BR2_PACKAGE_DANTE is not set
+# BR2_PACKAGE_DARKHTTPD is not set
+# BR2_PACKAGE_DHCPCD is not set
+# BR2_PACKAGE_DHCPDUMP is not set
+# BR2_PACKAGE_DNSMASQ is not set
+# BR2_PACKAGE_DRBD_UTILS is not set
+# BR2_PACKAGE_DROPBEAR is not set
+# BR2_PACKAGE_EBTABLES is not set
+
+#
+# ebtables needs a glibc or uClibc toolchain
+#
+
+#
+# ejabberd needs erlang, toolchain w/ C++
+#
+# BR2_PACKAGE_ETHTOOL is not set
+# BR2_PACKAGE_FAIFA is not set
+# BR2_PACKAGE_FASTD is not set
+# BR2_PACKAGE_FCGIWRAP is not set
+# BR2_PACKAGE_FPING is not set
+# BR2_PACKAGE_FREESWITCH is not set
+# BR2_PACKAGE_GESFTPSERVER is not set
+
+#
+# gupnp-tools needs libgtk3
+#
+# BR2_PACKAGE_HANS is not set
+# BR2_PACKAGE_HIAWATHA is not set
+# BR2_PACKAGE_HOSTAPD is not set
+# BR2_PACKAGE_HTTPING is not set
+# BR2_PACKAGE_IBRDTN_TOOLS is not set
+# BR2_PACKAGE_IBRDTND is not set
+# BR2_PACKAGE_IFTOP is not set
+# BR2_PACKAGE_IFUPDOWN_SCRIPTS is not set
+# BR2_PACKAGE_IGD2_FOR_LINUX is not set
+
+#
+# igh-ethercat needs a Linux kernel to be built
+#
+# BR2_PACKAGE_IGMPPROXY is not set
+# BR2_PACKAGE_INADYN is not set
+# BR2_PACKAGE_IODINE is not set
+# BR2_PACKAGE_IPERF is not set
+# BR2_PACKAGE_IPERF3 is not set
+# BR2_PACKAGE_IPROUTE2 is not set
+# BR2_PACKAGE_IPSEC_TOOLS is not set
+# BR2_PACKAGE_IPSET is not set
+# BR2_PACKAGE_IPTABLES is not set
+# BR2_PACKAGE_IPTRAF_NG is not set
+# BR2_PACKAGE_IPUTILS is not set
+# BR2_PACKAGE_IRSSI is not set
+# BR2_PACKAGE_IW is not set
+# BR2_PACKAGE_JANUS_GATEWAY is not set
+# BR2_PACKAGE_KEEPALIVED is not set
+# BR2_PACKAGE_KISMET is not set
+# BR2_PACKAGE_KNOCK is not set
+# BR2_PACKAGE_LEAFNODE2 is not set
+# BR2_PACKAGE_LFT is not set
+# BR2_PACKAGE_LFTP is not set
+# BR2_PACKAGE_LIGHTTPD is not set
+# BR2_PACKAGE_LINKNX is not set
+# BR2_PACKAGE_LINKS is not set
+# BR2_PACKAGE_LINPHONE is not set
+# BR2_PACKAGE_LINUX_ZIGBEE is not set
+# BR2_PACKAGE_LINUXPTP is not set
+# BR2_PACKAGE_LLDPD is not set
+# BR2_PACKAGE_LRZSZ is not set
+# BR2_PACKAGE_MACCHANGER is not set
+# BR2_PACKAGE_MEMCACHED is not set
+# BR2_PACKAGE_MII_DIAG is not set
+# BR2_PACKAGE_MINIDLNA is not set
+# BR2_PACKAGE_MINISSDPD is not set
+# BR2_PACKAGE_MJPG_STREAMER is not set
+
+#
+# modemmanager needs udev /dev management and a toolchain w/ wchar, threads
+#
+BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
+# BR2_PACKAGE_MONGREL2 is not set
+# BR2_PACKAGE_MONKEY is not set
+# BR2_PACKAGE_MOSQUITTO is not set
+# BR2_PACKAGE_MROUTED is not set
+# BR2_PACKAGE_MTR is not set
+# BR2_PACKAGE_NBD is not set
+# BR2_PACKAGE_NCFTP is not set
+# BR2_PACKAGE_NDISC6 is not set
+# BR2_PACKAGE_NETATALK is not set
+# BR2_PACKAGE_NETPLUG is not set
+# BR2_PACKAGE_NETSNMP is not set
+# BR2_PACKAGE_NETSTAT_NAT is not set
+
+#
+# NetworkManager needs udev /dev management and a glibc toolchain w/ headers >= 3.7, dynamic library
+#
+# BR2_PACKAGE_NFACCT is not set
+
+#
+# nftables needs a toolchain w/ wchar, headers >= 3.12
+#
+# BR2_PACKAGE_NGINX is not set
+# BR2_PACKAGE_NGIRCD is not set
+# BR2_PACKAGE_NGREP is not set
+# BR2_PACKAGE_NLOAD is not set
+# BR2_PACKAGE_NMAP is not set
+# BR2_PACKAGE_NOIP is not set
+# BR2_PACKAGE_NTP is not set
+# BR2_PACKAGE_NUTTCP is not set
+# BR2_PACKAGE_ODHCP6C is not set
+# BR2_PACKAGE_ODHCPLOC is not set
+# BR2_PACKAGE_OLSR is not set
+# BR2_PACKAGE_OPEN_PLC_UTILS is not set
+# BR2_PACKAGE_OPENNTPD is not set
+# BR2_PACKAGE_OPENOBEX is not set
+# BR2_PACKAGE_OPENSSH is not set
+# BR2_PACKAGE_OPENSWAN is not set
+# BR2_PACKAGE_OPENVPN is not set
+# BR2_PACKAGE_P910ND is not set
+# BR2_PACKAGE_PHIDGETWEBSERVICE is not set
+# BR2_PACKAGE_PHYTOOL is not set
+# BR2_PACKAGE_POUND is not set
+# BR2_PACKAGE_PPPD is not set
+# BR2_PACKAGE_PPTP_LINUX is not set
+# BR2_PACKAGE_PRIVOXY is not set
+# BR2_PACKAGE_PROFTPD is not set
+
+#
+# prosody needs the lua interpreter
+#
+# BR2_PACKAGE_PROXYCHAINS_NG is not set
+# BR2_PACKAGE_PTPD is not set
+# BR2_PACKAGE_PTPD2 is not set
+# BR2_PACKAGE_PURE_FTPD is not set
+# BR2_PACKAGE_PUTTY is not set
+# BR2_PACKAGE_QUAGGA is not set
+
+#
+# rabbitmq-server needs erlang
+#
+# BR2_PACKAGE_RADVD is not set
+# BR2_PACKAGE_RP_PPPOE is not set
+# BR2_PACKAGE_RPCBIND is not set
+# BR2_PACKAGE_RSH_REDONE is not set
+# BR2_PACKAGE_RSYNC is not set
+# BR2_PACKAGE_RTORRENT is not set
+# BR2_PACKAGE_RTPTOOLS is not set
+# BR2_PACKAGE_S6_DNS is not set
+# BR2_PACKAGE_S6_NETWORKING is not set
+# BR2_PACKAGE_SAMBA4 is not set
+# BR2_PACKAGE_SCONESERVER is not set
+# BR2_PACKAGE_SER2NET is not set
+# BR2_PACKAGE_SHAIRPORT_SYNC is not set
+# BR2_PACKAGE_SHELLINABOX is not set
+# BR2_PACKAGE_SMCROUTE is not set
+# BR2_PACKAGE_SNGREP is not set
+# BR2_PACKAGE_SOCAT is not set
+# BR2_PACKAGE_SOCKETCAND is not set
+# BR2_PACKAGE_SOFTETHER is not set
+# BR2_PACKAGE_SPAWN_FCGI is not set
+# BR2_PACKAGE_SPICE_PROTOCOL is not set
+# BR2_PACKAGE_SQUID is not set
+# BR2_PACKAGE_SSHPASS is not set
+# BR2_PACKAGE_SSLH is not set
+# BR2_PACKAGE_STRONGSWAN is not set
+# BR2_PACKAGE_STUNNEL is not set
+# BR2_PACKAGE_TCPDUMP is not set
+# BR2_PACKAGE_TCPING is not set
+# BR2_PACKAGE_TCPREPLAY is not set
+# BR2_PACKAGE_THTTPD is not set
+# BR2_PACKAGE_TINC is not set
+# BR2_PACKAGE_TINYHTTPD is not set
+# BR2_PACKAGE_TN5250 is not set
+# BR2_PACKAGE_TOR is not set
+# BR2_PACKAGE_TRANSMISSION is not set
+# BR2_PACKAGE_TUNCTL is not set
+# BR2_PACKAGE_TVHEADEND is not set
+# BR2_PACKAGE_UDPCAST is not set
+# BR2_PACKAGE_UHTTPD is not set
+# BR2_PACKAGE_ULOGD is not set
+# BR2_PACKAGE_USHARE is not set
+# BR2_PACKAGE_USSP_PUSH is not set
+# BR2_PACKAGE_VDE2 is not set
+# BR2_PACKAGE_VDR is not set
+# BR2_PACKAGE_VNSTAT is not set
+# BR2_PACKAGE_VPNC is not set
+# BR2_PACKAGE_VSFTPD is not set
+# BR2_PACKAGE_VTUN is not set
+# BR2_PACKAGE_WAVEMON is not set
+# BR2_PACKAGE_WIREGUARD is not set
+# BR2_PACKAGE_WIRELESS_REGDB is not set
+# BR2_PACKAGE_WIRELESS_TOOLS is not set
+# BR2_PACKAGE_WIRESHARK is not set
+# BR2_PACKAGE_WPA_SUPPLICANT is not set
+# BR2_PACKAGE_WPAN_TOOLS is not set
+# BR2_PACKAGE_XINETD is not set
+# BR2_PACKAGE_XL2TP is not set
+
+#
+# xtables-addons needs a Linux kernel to be built
+#
+# BR2_PACKAGE_ZNC is not set
+
+#
+# Package managers
+#
+
+#
+# -------------------------------------------------------
+#
+
+#
+# Please note:                                           
+#
+
+#
+# - Buildroot does *not* generate binary packages,       
+#
+
+#
+# - Buildroot does *not* install any package database.   
+#
+
+#
+# *                                                      
+#
+
+#
+# It is up to you to provide those by yourself if you    
+#
+
+#
+# want to use any of those package managers.             
+#
+
+#
+# *                                                      
+#
+
+#
+# See the manual:                                        
+#
+
+#
+# http://buildroot.org/manual.html#faq-no-binary-packages
+#
+
+#
+# -------------------------------------------------------
+#
+# BR2_PACKAGE_OPKG is not set
+
+#
+# Real-Time
+#
+BR2_PACKAGE_XENOMAI_ARCH_SUPPORTS=y
+# BR2_PACKAGE_XENOMAI is not set
+
+#
+# Security
+#
+# BR2_PACKAGE_CHECKPOLICY is not set
+# BR2_PACKAGE_PAXTEST is not set
+# BR2_PACKAGE_POLICYCOREUTILS is not set
+# BR2_PACKAGE_REFPOLICY is not set
+# BR2_PACKAGE_RESTORECOND is not set
+# BR2_PACKAGE_SELINUX_PYTHON is not set
+# BR2_PACKAGE_SEMODULE_UTILS is not set
+# BR2_PACKAGE_SETOOLS is not set
+
+#
+# Shell and utilities
+#
+
+#
+# Shells
+#
+# BR2_PACKAGE_MKSH is not set
+
+#
+# Utilities
+#
+# BR2_PACKAGE_AT is not set
+# BR2_PACKAGE_CCRYPT is not set
+# BR2_PACKAGE_DIALOG is not set
+# BR2_PACKAGE_DTACH is not set
+# BR2_PACKAGE_EASY_RSA is not set
+# BR2_PACKAGE_FILE is not set
+# BR2_PACKAGE_GNUPG is not set
+# BR2_PACKAGE_GNUPG2 is not set
+# BR2_PACKAGE_INOTIFY_TOOLS is not set
+# BR2_PACKAGE_LOCKFILE_PROGS is not set
+# BR2_PACKAGE_LOGROTATE is not set
+# BR2_PACKAGE_LOGSURFER is not set
+# BR2_PACKAGE_PDMENU is not set
+# BR2_PACKAGE_PINENTRY is not set
+# BR2_PACKAGE_RANGER is not set
+# BR2_PACKAGE_SCREEN is not set
+# BR2_PACKAGE_SUDO is not set
+# BR2_PACKAGE_TMUX is not set
+# BR2_PACKAGE_XMLSTARLET is not set
+# BR2_PACKAGE_XXHASH is not set
+
+#
+# System tools
+#
+# BR2_PACKAGE_ACL is not set
+# BR2_PACKAGE_ANDROID_TOOLS is not set
+# BR2_PACKAGE_ATOP is not set
+# BR2_PACKAGE_ATTR is not set
+BR2_PACKAGE_AUDIT_ARCH_SUPPORTS=y
+# BR2_PACKAGE_AUDIT is not set
+# BR2_PACKAGE_CGROUPFS_MOUNT is not set
+
+#
+# circus needs Python and a toolchain w/ C++, threads
+#
+# BR2_PACKAGE_CPULOAD is not set
+# BR2_PACKAGE_DAEMON is not set
+# BR2_PACKAGE_DC3DD is not set
+# BR2_PACKAGE_DDRESCUE is not set
+
+#
+# efibootmgr needs a glibc or uClibc toolchain w/ dynamic library, headers >= 3.12, gcc >= 4.9
+#
+BR2_PACKAGE_EFIVAR_ARCH_SUPPORTS=y
+
+#
+# efivar needs a glibc or uClibc toolchain w/ dynamic library, headers >= 3.12, gcc >= 4.9
+#
+
+#
+# emlog needs a Linux kernel to be built
+#
+# BR2_PACKAGE_FTOP is not set
+# BR2_PACKAGE_GETENT is not set
+# BR2_PACKAGE_HTOP is not set
+BR2_PACKAGE_INITSCRIPTS=y
+
+#
+# iotop depends on python or python3
+#
+# BR2_PACKAGE_IPRUTILS is not set
+# BR2_PACKAGE_IRQBALANCE is not set
+# BR2_PACKAGE_KEYUTILS is not set
+# BR2_PACKAGE_KMOD is not set
+# BR2_PACKAGE_KVMTOOL is not set
+# BR2_PACKAGE_LXC is not set
+# BR2_PACKAGE_MONIT is not set
+# BR2_PACKAGE_NCDU is not set
+# BR2_PACKAGE_NUT is not set
+# BR2_PACKAGE_POLKIT is not set
+# BR2_PACKAGE_PROCRANK_LINUX is not set
+# BR2_PACKAGE_PWGEN is not set
+# BR2_PACKAGE_QUOTA is not set
+# BR2_PACKAGE_RAUC is not set
+# BR2_PACKAGE_S6 is not set
+# BR2_PACKAGE_S6_LINUX_INIT is not set
+# BR2_PACKAGE_S6_LINUX_UTILS is not set
+# BR2_PACKAGE_S6_PORTABLE_UTILS is not set
+# BR2_PACKAGE_S6_RC is not set
+# BR2_PACKAGE_SCRUB is not set
+# BR2_PACKAGE_SCRYPT is not set
+# BR2_PACKAGE_SMACK is not set
+
+#
+# supervisor needs the python interpreter
+#
+# BR2_PACKAGE_SWUPDATE is not set
+BR2_PACKAGE_SYSTEMD_ARCH_SUPPORTS=y
+# BR2_PACKAGE_TPM_TOOLS is not set
+# BR2_PACKAGE_UNSCD is not set
+# BR2_PACKAGE_UTIL_LINUX is not set
+# BR2_PACKAGE_XEN is not set
+BR2_PACKAGE_XVISOR_ARCH_SUPPORTS=y
+# BR2_PACKAGE_XVISOR is not set
+
+#
+# Text editors and viewers
+#
+# BR2_PACKAGE_ED is not set
+# BR2_PACKAGE_JOE is not set
+# BR2_PACKAGE_MC is not set
+# BR2_PACKAGE_NANO is not set
+# BR2_PACKAGE_UEMACS is not set
+
+#
+# Filesystem images
+#
+# BR2_TARGET_ROOTFS_AXFS is not set
+# BR2_TARGET_ROOTFS_CLOOP is not set
+# BR2_TARGET_ROOTFS_CPIO is not set
+# BR2_TARGET_ROOTFS_CRAMFS is not set
+BR2_TARGET_ROOTFS_EXT2=y
+BR2_TARGET_ROOTFS_EXT2_2=y
+# BR2_TARGET_ROOTFS_EXT2_2r0 is not set
+BR2_TARGET_ROOTFS_EXT2_2r1=y
+# BR2_TARGET_ROOTFS_EXT2_3 is not set
+# BR2_TARGET_ROOTFS_EXT2_4 is not set
+BR2_TARGET_ROOTFS_EXT2_GEN=2
+BR2_TARGET_ROOTFS_EXT2_REV=1
+BR2_TARGET_ROOTFS_EXT2_LABEL=""
+BR2_TARGET_ROOTFS_EXT2_SIZE="60M"
+BR2_TARGET_ROOTFS_EXT2_INODES=0
+BR2_TARGET_ROOTFS_EXT2_RESBLKS=5
+BR2_TARGET_ROOTFS_EXT2_MKFS_OPTIONS="-O ^64bit"
+BR2_TARGET_ROOTFS_EXT2_NONE=y
+# BR2_TARGET_ROOTFS_EXT2_GZIP is not set
+# BR2_TARGET_ROOTFS_EXT2_BZIP2 is not set
+# BR2_TARGET_ROOTFS_EXT2_LZMA is not set
+# BR2_TARGET_ROOTFS_EXT2_LZO is not set
+# BR2_TARGET_ROOTFS_EXT2_XZ is not set
+
+#
+# initramfs needs a Linux kernel to be built
+#
+# BR2_TARGET_ROOTFS_JFFS2 is not set
+# BR2_TARGET_ROOTFS_ROMFS is not set
+# BR2_TARGET_ROOTFS_SQUASHFS is not set
+BR2_TARGET_ROOTFS_TAR=y
+# BR2_TARGET_ROOTFS_TAR_NONE is not set
+BR2_TARGET_ROOTFS_TAR_GZIP=y
+# BR2_TARGET_ROOTFS_TAR_BZIP2 is not set
+# BR2_TARGET_ROOTFS_TAR_LZMA is not set
+# BR2_TARGET_ROOTFS_TAR_LZO is not set
+# BR2_TARGET_ROOTFS_TAR_XZ is not set
+BR2_TARGET_ROOTFS_TAR_OPTIONS=""
+# BR2_TARGET_ROOTFS_UBIFS is not set
+# BR2_TARGET_ROOTFS_YAFFS2 is not set
+
+#
+# Bootloaders
+#
+# BR2_TARGET_AFBOOT_STM32 is not set
+# BR2_TARGET_BAREBOX is not set
+# BR2_TARGET_MXS_BOOTLETS is not set
+# BR2_TARGET_TS4800_MBRBOOT is not set
+# BR2_TARGET_UBOOT is not set
+# BR2_TARGET_XLOADER is not set
+
+#
+# Host utilities
+#
+# BR2_PACKAGE_HOST_AESPIPE is not set
+# BR2_PACKAGE_HOST_ANDROID_TOOLS is not set
+# BR2_PACKAGE_HOST_CBOOTIMAGE is not set
+# BR2_PACKAGE_HOST_CHECKPOLICY is not set
+# BR2_PACKAGE_HOST_CMAKE is not set
+# BR2_PACKAGE_HOST_CRAMFS is not set
+# BR2_PACKAGE_HOST_CRYPTSETUP is not set
+# BR2_PACKAGE_HOST_DFU_UTIL is not set
+# BR2_PACKAGE_HOST_DOS2UNIX is not set
+# BR2_PACKAGE_HOST_DOSFSTOOLS is not set
+# BR2_PACKAGE_HOST_DTC is not set
+BR2_PACKAGE_HOST_E2FSPROGS=y
+# BR2_PACKAGE_HOST_E2TOOLS is not set
+# BR2_PACKAGE_HOST_FAKETIME is not set
+# BR2_PACKAGE_HOST_FWUP is not set
+# BR2_PACKAGE_HOST_GENEXT2FS is not set
+# BR2_PACKAGE_HOST_GENIMAGE is not set
+# BR2_PACKAGE_HOST_GENPART is not set
+BR2_PACKAGE_HOST_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
+# BR2_PACKAGE_HOST_GPTFDISK is not set
+# BR2_PACKAGE_HOST_IMX_USB_LOADER is not set
+# BR2_PACKAGE_HOST_JQ is not set
+# BR2_PACKAGE_HOST_JSMIN is not set
+# BR2_PACKAGE_HOST_LPC3250LOADER is not set
+# BR2_PACKAGE_HOST_LTTNG_BABELTRACE is not set
+
+#
+# mfgtools needs host gcc >= 4.8
+#
+# BR2_PACKAGE_HOST_MKPASSWD is not set
+# BR2_PACKAGE_HOST_MTD is not set
+# BR2_PACKAGE_HOST_MTOOLS is not set
+# BR2_PACKAGE_HOST_MXSLDR is not set
+# BR2_PACKAGE_HOST_OMAP_U_BOOT_UTILS is not set
+# BR2_PACKAGE_HOST_OPENOCD is not set
+# BR2_PACKAGE_HOST_OPKG_UTILS is not set
+# BR2_PACKAGE_HOST_PARTED is not set
+BR2_PACKAGE_HOST_PATCHELF=y
+# BR2_PACKAGE_HOST_PKGCONF is not set
+# BR2_PACKAGE_HOST_PWGEN is not set
+# BR2_PACKAGE_HOST_PYTHON_LXML is not set
+# BR2_PACKAGE_HOST_PYTHON_SIX is not set
+# BR2_PACKAGE_HOST_QEMU is not set
+# BR2_PACKAGE_HOST_RASPBERRYPI_USBBOOT is not set
+# BR2_PACKAGE_HOST_RAUC is not set
+# BR2_PACKAGE_HOST_SQUASHFS is not set
+# BR2_PACKAGE_HOST_SUNXI_TOOLS is not set
+# BR2_PACKAGE_HOST_TEGRARCM is not set
+# BR2_PACKAGE_HOST_UBOOT_TOOLS is not set
+BR2_PACKAGE_HOST_UTIL_LINUX=y
+# BR2_PACKAGE_HOST_VBOOT_UTILS is not set
+# BR2_PACKAGE_HOST_XORRISO is not set
+# BR2_PACKAGE_HOST_ZIP is not set
+
+#
+# Legacy config options
+#
+
+#
+# Legacy options removed in 2017.11
+#
+BR2_TOOLCHAIN_EXTRA_EXTERNAL_LIBS=""
+# BR2_PACKAGE_RFKILL is not set
+# BR2_PACKAGE_UTIL_LINUX_RESET is not set
+# BR2_PACKAGE_POLICYCOREUTILS_AUDIT2ALLOW is not set
+# BR2_PACKAGE_POLICYCOREUTILS_RESTORECOND is not set
+# BR2_PACKAGE_SEPOLGEN is not set
+# BR2_PACKAGE_OPENOBEX_BLUEZ is not set
+# BR2_PACKAGE_OPENOBEX_LIBUSB is not set
+# BR2_PACKAGE_OPENOBEX_APPS is not set
+# BR2_PACKAGE_OPENOBEX_SYSLOG is not set
+# BR2_PACKAGE_OPENOBEX_DUMP is not set
+# BR2_PACKAGE_AICCU is not set
+# BR2_PACKAGE_UTIL_LINUX_LOGIN_UTILS is not set
+
+#
+# Legacy options removed in 2017.08
+#
+# BR2_TARGET_GRUB is not set
+# BR2_PACKAGE_SIMICSFS is not set
+# BR2_BINUTILS_VERSION_2_26_X is not set
+BR2_XTENSA_OVERLAY_DIR=""
+BR2_XTENSA_CUSTOM_NAME=""
+# BR2_PACKAGE_HOST_MKE2IMG is not set
+BR2_TARGET_ROOTFS_EXT2_BLOCKS=0
+BR2_TARGET_ROOTFS_EXT2_EXTRA_INODES=0
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_CDXAPARSE is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_DATAURISRC is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_DCCP is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_HDVPARSE is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_MVE is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_NUVDEMUX is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_PATCHDETECT is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_SDI is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_TTA is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_VIDEOMEASURE is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_APEXSINK is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_SDL is not set
+# BR2_PACKAGE_GST1_PLUGINS_UGLY_PLUGIN_MAD is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_WEBRTC is not set
+# BR2_STRIP_none is not set
+# BR2_PACKAGE_BEECRYPT_CPP is not set
+# BR2_PACKAGE_SPICE_CLIENT is not set
+# BR2_PACKAGE_SPICE_GUI is not set
+# BR2_PACKAGE_SPICE_TUNNEL is not set
+# BR2_PACKAGE_INPUT_TOOLS is not set
+# BR2_PACKAGE_INPUT_TOOLS_INPUTATTACH is not set
+# BR2_PACKAGE_INPUT_TOOLS_JSCAL is not set
+# BR2_PACKAGE_INPUT_TOOLS_JSTEST is not set
+# BR2_TOOLCHAIN_EXTERNAL_CODESOURCERY_SH is not set
+# BR2_TOOLCHAIN_EXTERNAL_CODESOURCERY_X86 is not set
+# BR2_GCC_VERSION_4_8_X is not set
+
+#
+# Legacy options removed in 2017.05
+#
+# BR2_PACKAGE_SUNXI_MALI_R2P4 is not set
+# BR2_PACKAGE_NODEJS_MODULES_COFFEESCRIPT is not set
+# BR2_PACKAGE_NODEJS_MODULES_EXPRESS is not set
+# BR2_PACKAGE_BLUEZ5_UTILS_GATTTOOL is not set
+# BR2_PACKAGE_OPENOCD_FT2XXX is not set
+# BR2_PACKAGE_KODI_RTMPDUMP is not set
+# BR2_PACKAGE_KODI_VISUALISATION_FOUNTAIN is not set
+# BR2_PACKAGE_PORTMAP is not set
+# BR2_BINUTILS_VERSION_2_25_X is not set
+# BR2_TOOLCHAIN_BUILDROOT_INET_RPC is not set
+BR2_TARGET_ROOTFS_EXT2_EXTRA_BLOCKS=0
+# BR2_PACKAGE_SYSTEMD_KDBUS is not set
+# BR2_PACKAGE_POLARSSL is not set
+# BR2_NBD_CLIENT is not set
+# BR2_NBD_SERVER is not set
+# BR2_PACKAGE_GMOCK is not set
+# BR2_KERNEL_HEADERS_4_8 is not set
+# BR2_KERNEL_HEADERS_3_18 is not set
+# BR2_GLIBC_VERSION_2_22 is not set
+
+#
+# Legacy options removed in 2017.02
+#
+# BR2_PACKAGE_PERL_DB_FILE is not set
+# BR2_KERNEL_HEADERS_4_7 is not set
+# BR2_KERNEL_HEADERS_4_6 is not set
+# BR2_KERNEL_HEADERS_4_5 is not set
+# BR2_KERNEL_HEADERS_3_14 is not set
+# BR2_TOOLCHAIN_EXTERNAL_MUSL_CROSS is not set
+# BR2_UCLIBC_INSTALL_TEST_SUITE is not set
+# BR2_TOOLCHAIN_EXTERNAL_BLACKFIN_UCLINUX is not set
+# BR2_PACKAGE_MAKEDEVS is not set
+# BR2_TOOLCHAIN_EXTERNAL_ARAGO_ARMV7A is not set
+# BR2_TOOLCHAIN_EXTERNAL_ARAGO_ARMV5TE is not set
+# BR2_PACKAGE_SNOWBALL_HDMISERVICE is not set
+# BR2_PACKAGE_SNOWBALL_INIT is not set
+# BR2_GDB_VERSION_7_9 is not set
+
+#
+# Legacy options removed in 2016.11
+#
+# BR2_PACKAGE_PHP_SAPI_CLI_CGI is not set
+# BR2_PACKAGE_PHP_SAPI_CLI_FPM is not set
+# BR2_PACKAGE_WVSTREAMS is not set
+# BR2_PACKAGE_WVDIAL is not set
+# BR2_PACKAGE_WEBKITGTK24 is not set
+# BR2_PACKAGE_TORSMO is not set
+# BR2_PACKAGE_SSTRIP is not set
+# BR2_KERNEL_HEADERS_4_3 is not set
+# BR2_KERNEL_HEADERS_4_2 is not set
+# BR2_PACKAGE_KODI_ADDON_XVDR is not set
+# BR2_PACKAGE_IPKG is not set
+# BR2_GCC_VERSION_4_7_X is not set
+# BR2_BINUTILS_VERSION_2_24_X is not set
+# BR2_PACKAGE_WESTON_RPI is not set
+# BR2_GCC_VERSION_4_8_ARC is not set
+# BR2_KERNEL_HEADERS_4_0 is not set
+# BR2_KERNEL_HEADERS_3_19 is not set
+# BR2_PACKAGE_LIBEVAS_GENERIC_LOADERS is not set
+# BR2_PACKAGE_ELEMENTARY is not set
+# BR2_LINUX_KERNEL_CUSTOM_LOCAL is not set
+
+#
+# Legacy options removed in 2016.08
+#
+# BR2_PACKAGE_EFL_JP2K is not set
+# BR2_PACKAGE_SYSTEMD_COMPAT is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_LIVEADDER is not set
+# BR2_PACKAGE_LIBFSLVPUWRAP is not set
+# BR2_PACKAGE_LIBFSLPARSER is not set
+# BR2_PACKAGE_LIBFSLCODEC is not set
+# BR2_PACKAGE_UBOOT_TOOLS_MKIMAGE_FIT_SIGNATURE_SUPPORT is not set
+# BR2_PTHREADS_OLD is not set
+# BR2_BINUTILS_VERSION_2_23_X is not set
+# BR2_TOOLCHAIN_BUILDROOT_EGLIBC is not set
+# BR2_GDB_VERSION_7_8 is not set
+
+#
+# Legacy options removed in 2016.05
+#
+# BR2_PACKAGE_OPENVPN_CRYPTO_POLARSSL is not set
+# BR2_PACKAGE_NGINX_HTTP_SPDY_MODULE is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_RTP is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_MPG123 is not set
+# BR2_TOOLCHAIN_EXTERNAL_CODESOURCERY_POWERPC is not set
+# BR2_TOOLCHAIN_EXTERNAL_CODESOURCERY_POWERPC_E500V2 is not set
+# BR2_x86_i386 is not set
+# BR2_PACKAGE_QT5WEBKIT_EXAMPLES is not set
+# BR2_PACKAGE_QT5QUICK1 is not set
+BR2_TARGET_UBOOT_CUSTOM_PATCH_DIR=""
+# BR2_PACKAGE_XDRIVER_XF86_INPUT_VOID is not set
+# BR2_KERNEL_HEADERS_3_17 is not set
+# BR2_GDB_VERSION_7_7 is not set
+# BR2_PACKAGE_FOOMATIC_FILTERS is not set
+# BR2_PACKAGE_SAMBA is not set
+# BR2_PACKAGE_KODI_WAVPACK is not set
+# BR2_PACKAGE_KODI_RSXS is not set
+# BR2_PACKAGE_KODI_GOOM is not set
+# BR2_PACKAGE_SYSTEMD_ALL_EXTRAS is not set
+# BR2_GCC_VERSION_4_5_X is not set
+# BR2_PACKAGE_SQLITE_READLINE is not set
+
+#
+# Legacy options removed in 2016.02
+#
+# BR2_PACKAGE_DOVECOT_BZIP2 is not set
+# BR2_PACKAGE_DOVECOT_ZLIB is not set
+# BR2_PACKAGE_E2FSPROGS_FINDFS is not set
+# BR2_PACKAGE_OPENPOWERLINK_DEBUG_LEVEL is not set
+# BR2_PACKAGE_OPENPOWERLINK_KERNEL_MODULE is not set
+# BR2_PACKAGE_OPENPOWERLINK_LIBPCAP is not set
+# BR2_LINUX_KERNEL_SAME_AS_HEADERS is not set
+# BR2_PACKAGE_CUPS_PDFTOPS is not set
+# BR2_KERNEL_HEADERS_3_16 is not set
+# BR2_PACKAGE_PYTHON_PYXML is not set
+# BR2_ENABLE_SSP is not set
+# BR2_PACKAGE_DIRECTFB_CLE266 is not set
+# BR2_PACKAGE_DIRECTFB_UNICHROME is not set
+# BR2_PACKAGE_LIBELEMENTARY is not set
+# BR2_PACKAGE_LIBEINA is not set
+# BR2_PACKAGE_LIBEET is not set
+# BR2_PACKAGE_LIBEVAS is not set
+# BR2_PACKAGE_LIBECORE is not set
+# BR2_PACKAGE_LIBEDBUS is not set
+# BR2_PACKAGE_LIBEFREET is not set
+# BR2_PACKAGE_LIBEIO is not set
+# BR2_PACKAGE_LIBEMBRYO is not set
+# BR2_PACKAGE_LIBEDJE is not set
+# BR2_PACKAGE_LIBETHUMB is not set
+# BR2_PACKAGE_INFOZIP is not set
+# BR2_BR2_PACKAGE_NODEJS_0_10_X is not set
+# BR2_BR2_PACKAGE_NODEJS_0_12_X is not set
+# BR2_BR2_PACKAGE_NODEJS_4_X is not set
+
+#
+# Legacy options removed in 2015.11
+#
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_REAL is not set
+# BR2_PACKAGE_MEDIA_CTL is not set
+# BR2_PACKAGE_SCHIFRA is not set
+# BR2_PACKAGE_ZXING is not set
+# BR2_PACKAGE_BLACKBOX is not set
+# BR2_KERNEL_HEADERS_3_0 is not set
+# BR2_KERNEL_HEADERS_3_11 is not set
+# BR2_KERNEL_HEADERS_3_13 is not set
+# BR2_KERNEL_HEADERS_3_15 is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_ANDI is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_BLTLOAD is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_CPULOAD is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_DATABUFFER is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_DIOLOAD is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_DOK is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_DRIVERTEST is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_FIRE is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_FLIP is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_FONTS is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_INPUT is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_JOYSTICK is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_KNUCKLES is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_LAYER is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_MATRIX is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_MATRIX_WATER is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_NEO is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_NETLOAD is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_PALETTE is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_PARTICLE is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_PORTER is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_STRESS is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_TEXTURE is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_VIDEO is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_VIDEO_PARTICLE is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES_WINDOW is not set
+# BR2_PACKAGE_KOBS_NG is not set
+# BR2_PACKAGE_SAWMAN is not set
+# BR2_PACKAGE_DIVINE is not set
+
+#
+# Legacy options removed in 2015.08
+#
+# BR2_PACKAGE_KODI_PVR_ADDONS is not set
+# BR2_BINUTILS_VERSION_2_23_2 is not set
+# BR2_BINUTILS_VERSION_2_24 is not set
+# BR2_BINUTILS_VERSION_2_25 is not set
+# BR2_PACKAGE_PERF is not set
+# BR2_BINUTILS_VERSION_2_22 is not set
+# BR2_PACKAGE_GPU_VIV_BIN_MX6Q is not set
+# BR2_TARGET_UBOOT_NETWORK is not set
+
+#
+# Legacy options removed in 2015.05
+#
+# BR2_TARGET_ROOTFS_JFFS2_NANDFLASH_512_16K is not set
+# BR2_TARGET_ROOTFS_JFFS2_NANDFLASH_2K_128K is not set
+# BR2_PACKAGE_MONO_20 is not set
+# BR2_PACKAGE_MONO_40 is not set
+# BR2_PACKAGE_MONO_45 is not set
+# BR2_CIVETWEB_WITH_LUA is not set
+# BR2_PACKAGE_TIFF_TIFF2PDF is not set
+# BR2_PACKAGE_TIFF_TIFFCP is not set
+# BR2_LINUX_KERNEL_EXT_RTAI_PATCH is not set
+# BR2_TARGET_GENERIC_PASSWD_DES is not set
+# BR2_PACKAGE_GTK2_THEME_HICOLOR is not set
+# BR2_PACKAGE_VALGRIND_PTRCHECK is not set
+
+#
+# Legacy options removed in 2015.02
+#
+# BR2_PACKAGE_LIBGC is not set
+# BR2_PACKAGE_WDCTL is not set
+# BR2_PACKAGE_UTIL_LINUX_ARCH is not set
+# BR2_PACKAGE_UTIL_LINUX_DDATE is not set
+# BR2_PACKAGE_RPM_BZIP2_PAYLOADS is not set
+# BR2_PACKAGE_RPM_XZ_PAYLOADS is not set
+# BR2_PACKAGE_M4 is not set
+# BR2_PACKAGE_FLEX_BINARY is not set
+# BR2_PACKAGE_BISON is not set
+# BR2_PACKAGE_GOB2 is not set
+# BR2_PACKAGE_DISTCC is not set
+# BR2_PACKAGE_HASERL_VERSION_0_8_X is not set
+# BR2_PACKAGE_STRONGSWAN_TOOLS is not set
+# BR2_PACKAGE_XBMC_ADDON_XVDR is not set
+# BR2_PACKAGE_XBMC_PVR_ADDONS is not set
+# BR2_PACKAGE_XBMC is not set
+# BR2_PACKAGE_XBMC_ALSA_LIB is not set
+# BR2_PACKAGE_XBMC_AVAHI is not set
+# BR2_PACKAGE_XBMC_DBUS is not set
+# BR2_PACKAGE_XBMC_LIBBLURAY is not set
+# BR2_PACKAGE_XBMC_GOOM is not set
+# BR2_PACKAGE_XBMC_RSXS is not set
+# BR2_PACKAGE_XBMC_LIBCEC is not set
+# BR2_PACKAGE_XBMC_LIBMICROHTTPD is not set
+# BR2_PACKAGE_XBMC_LIBNFS is not set
+# BR2_PACKAGE_XBMC_RTMPDUMP is not set
+# BR2_PACKAGE_XBMC_LIBSHAIRPLAY is not set
+# BR2_PACKAGE_XBMC_LIBSMBCLIENT is not set
+# BR2_PACKAGE_XBMC_LIBTHEORA is not set
+# BR2_PACKAGE_XBMC_LIBUSB is not set
+# BR2_PACKAGE_XBMC_LIBVA is not set
+# BR2_PACKAGE_XBMC_WAVPACK is not set
+# BR2_PREFER_STATIC_LIB is not set
+
+#
+# Legacy options removed in 2014.11
+#
+# BR2_x86_generic is not set
+# BR2_GCC_VERSION_4_4_X is not set
+# BR2_sparc_sparchfleon is not set
+# BR2_sparc_sparchfleonv8 is not set
+# BR2_sparc_sparcsfleon is not set
+# BR2_sparc_sparcsfleonv8 is not set
+# BR2_PACKAGE_LINUX_FIRMWARE_XC5000 is not set
+# BR2_PACKAGE_LINUX_FIRMWARE_CXGB4 is not set
+# BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_3160_7260_7 is not set
+# BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_3160_7260_8 is not set
+
+#
+# Legacy options removed in 2014.08
+#
+# BR2_PACKAGE_LIBELF is not set
+# BR2_KERNEL_HEADERS_3_8 is not set
+# BR2_PACKAGE_GETTEXT_TOOLS is not set
+# BR2_PACKAGE_PROCPS is not set
+# BR2_BINUTILS_VERSION_2_20_1 is not set
+# BR2_BINUTILS_VERSION_2_21 is not set
+# BR2_BINUTILS_VERSION_2_23_1 is not set
+# BR2_UCLIBC_VERSION_0_9_32 is not set
+# BR2_GCC_VERSION_4_3_X is not set
+# BR2_GCC_VERSION_4_6_X is not set
+# BR2_GDB_VERSION_7_4 is not set
+# BR2_GDB_VERSION_7_5 is not set
+# BR2_BUSYBOX_VERSION_1_19_X is not set
+# BR2_BUSYBOX_VERSION_1_20_X is not set
+# BR2_BUSYBOX_VERSION_1_21_X is not set
+# BR2_PACKAGE_LIBV4L_DECODE_TM6000 is not set
+# BR2_PACKAGE_LIBV4L_IR_KEYTABLE is not set
+# BR2_PACKAGE_LIBV4L_V4L2_COMPLIANCE is not set
+# BR2_PACKAGE_LIBV4L_V4L2_CTL is not set
+# BR2_PACKAGE_LIBV4L_V4L2_DBG is not set
+
+#
+# Legacy options removed in 2014.05
+#
+# BR2_PACKAGE_EVTEST_CAPTURE is not set
+# BR2_KERNEL_HEADERS_3_6 is not set
+# BR2_KERNEL_HEADERS_3_7 is not set
+# BR2_PACKAGE_VALA is not set
+BR2_PACKAGE_TZDATA_ZONELIST=""
+# BR2_PACKAGE_LUA_INTERPRETER_EDITING_NONE is not set
+# BR2_PACKAGE_LUA_INTERPRETER_READLINE is not set
+# BR2_PACKAGE_LUA_INTERPRETER_LINENOISE is not set
+# BR2_PACKAGE_DVB_APPS_UTILS is not set
+# BR2_KERNEL_HEADERS_SNAP is not set
+# BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_UDEV is not set
+# BR2_PACKAGE_UDEV is not set
+# BR2_PACKAGE_UDEV_RULES_GEN is not set
+# BR2_PACKAGE_UDEV_ALL_EXTRAS is not set
+
+#
+# Legacy options removed in 2014.02
+#
+# BR2_sh2 is not set
+# BR2_sh3 is not set
+# BR2_sh3eb is not set
+# BR2_KERNEL_HEADERS_3_1 is not set
+# BR2_KERNEL_HEADERS_3_3 is not set
+# BR2_KERNEL_HEADERS_3_5 is not set
+# BR2_GDB_VERSION_7_2 is not set
+# BR2_GDB_VERSION_7_3 is not set
+# BR2_PACKAGE_CCACHE is not set
+# BR2_HAVE_DOCUMENTATION is not set
+# BR2_PACKAGE_AUTOMAKE is not set
+# BR2_PACKAGE_AUTOCONF is not set
+# BR2_PACKAGE_XSTROKE is not set
+# BR2_PACKAGE_LZMA is not set
+# BR2_PACKAGE_TTCP is not set
+# BR2_PACKAGE_LIBNFC_LLCP is not set
+# BR2_PACKAGE_MYSQL_CLIENT is not set
+# BR2_PACKAGE_SQUASHFS3 is not set
+# BR2_TARGET_ROOTFS_SQUASHFS3 is not set
+# BR2_PACKAGE_NETKITBASE is not set
+# BR2_PACKAGE_NETKITTELNET is not set
+# BR2_PACKAGE_LUASQL is not set
+# BR2_PACKAGE_LUACJSON is not set
+
+#
+# Legacy options removed in 2013.11
+#
+# BR2_PACKAGE_LVM2_DMSETUP_ONLY is not set
+# BR2_PACKAGE_QT_JAVASCRIPTCORE is not set
+# BR2_PACKAGE_MODULE_INIT_TOOLS is not set
+BR2_TARGET_UBOOT_CUSTOM_GIT_REPO_URL=""
+BR2_TARGET_UBOOT_CUSTOM_GIT_VERSION=""
+BR2_LINUX_KERNEL_CUSTOM_GIT_REPO_URL=""
+BR2_LINUX_KERNEL_CUSTOM_GIT_VERSION=""
+
+#
+# Legacy options removed in 2013.08
+#
+# BR2_ARM_OABI is not set
+# BR2_PACKAGE_DOSFSTOOLS_DOSFSCK is not set
+# BR2_PACKAGE_DOSFSTOOLS_DOSFSLABEL is not set
+# BR2_PACKAGE_DOSFSTOOLS_MKDOSFS is not set
+# BR2_ELF2FLT is not set
+# BR2_VFP_FLOAT is not set
+# BR2_PACKAGE_GCC_TARGET is not set
+# BR2_HAVE_DEVFILES is not set
+
+#
+# Legacy options removed in 2013.05
+#
+# BR2_PACKAGE_LINUX_FIRMWARE_RTL_8192 is not set
+# BR2_PACKAGE_LINUX_FIRMWARE_RTL_8712 is not set
+
+#
+# Legacy options removed in 2013.02
+#
+# BR2_sa110 is not set
+# BR2_sa1100 is not set
+# BR2_PACKAGE_GDISK is not set
+# BR2_PACKAGE_GDISK_GDISK is not set
+# BR2_PACKAGE_GDISK_SGDISK is not set
+# BR2_PACKAGE_GDB_HOST is not set
+# BR2_PACKAGE_DIRECTB_DITHER_RGB16 is not set
+# BR2_PACKAGE_DIRECTB_TESTS is not set
+
+#
+# Legacy options removed in 2012.11
+#
+# BR2_PACKAGE_CUSTOMIZE is not set
+# BR2_PACKAGE_XSERVER_xorg is not set
+# BR2_PACKAGE_XSERVER_tinyx is not set
+# BR2_PACKAGE_PTHREAD_STUBS is not set
+
+#
+# Legacy options removed in 2012.08
+#
+# BR2_PACKAGE_GETTEXT_STATIC is not set
+# BR2_PACKAGE_LIBINTL is not set
+# BR2_PACKAGE_INPUT_TOOLS_EVTEST is not set
+# BR2_BFIN_FDPIC is not set
+# BR2_BFIN_FLAT is not set

--- a/.devcontainer/a30/support/package-toolchain.sh
+++ b/.devcontainer/a30/support/package-toolchain.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cd /opt/
+tar --xz -cvf my282-toolchain.tar.xz my282-toolchain/
+mv my282-toolchain.tar.xz ~/workspace/
+
+printf "my282-toolchain.tar.xz can be shared as a blob\nby placing in support before calling 'make shell'\n"

--- a/.devcontainer/a30/support/patches/package/bison/110-glibc-change-work-around.patch
+++ b/.devcontainer/a30/support/patches/package/bison/110-glibc-change-work-around.patch
@@ -1,0 +1,33 @@
+Subject: Workaround change in glibc
+
+Temporary workaround to compile with glibc 2.28, which
+deprecated some constants
+
+Based on the workaround made for the tools/m4 package
+
+--- a/lib/stdio-impl.h
++++ b/lib/stdio-impl.h
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 
+--- a/lib/fseterr.c
++++ b/lib/fseterr.c
+@@ -29,7 +29,7 @@
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_flags |= _IO_ERR_SEEN;
+ #elif defined __sferror || defined __DragonFly__ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin */
+   fp_->_flags |= __SERR;

--- a/.devcontainer/a30/support/patches/package/e2fsprogs/000-fix-gcc-conflict.patch
+++ b/.devcontainer/a30/support/patches/package/e2fsprogs/000-fix-gcc-conflict.patch
@@ -1,0 +1,40 @@
+This patch prevents a conflict with glibc
+
+--- a/misc/create_inode.c
++++ b/misc/create_inode.c	
+@@ -392,7 +392,7 @@ static ssize_t my_pread(int fd, void *buf, size_t count, off_t offset)
+ }
+ #endif /* !defined HAVE_PREAD64 && !defined HAVE_PREAD */
+ 
+-static errcode_t copy_file_range(ext2_filsys fs, int fd, ext2_file_t e2_file,
++static errcode_t copy_file_chunk(ext2_filsys fs, int fd, ext2_file_t e2_file,
+ 				 off_t start, off_t end, char *buf,
+ 				 char *zerobuf)
+ {
+@@ -466,7 +466,7 @@ static errcode_t try_lseek_copy(ext2_filsys fs, int fd, struct stat *statbuf,
+ 
+ 		data_blk = data & ~(fs->blocksize - 1);
+ 		hole_blk = (hole + (fs->blocksize - 1)) & ~(fs->blocksize - 1);
+-		err = copy_file_range(fs, fd, e2_file, data_blk, hole_blk, buf,
++		err = copy_file_chunk(fs, fd, e2_file, data_blk, hole_blk, buf,
+ 				      zerobuf);
+ 		if (err)
+ 			return err;
+@@ -516,7 +516,7 @@ static errcode_t try_fiemap_copy(ext2_filsys fs, int fd, ext2_file_t e2_file,
+ 		}
+ 		for (i = 0, ext = ext_buf; i < fiemap_buf->fm_mapped_extents;
+ 		     i++, ext++) {
+-			err = copy_file_range(fs, fd, e2_file, ext->fe_logical,
++			err = copy_file_chunk(fs, fd, e2_file, ext->fe_logical,
+ 					      ext->fe_logical + ext->fe_length,
+ 					      buf, zerobuf);
+ 			if (err)
+@@ -569,7 +569,7 @@ static errcode_t copy_file(ext2_filsys fs, int fd, struct stat *statbuf,
+ 		goto out;
+ #endif
+ 
+-	err = copy_file_range(fs, fd, e2_file, 0, statbuf->st_size, buf,
++	err = copy_file_chunk(fs, fd, e2_file, 0, statbuf->st_size, buf,
+ 			      zerobuf);
+ out:
+ 	ext2fs_free_mem(&zerobuf);

--- a/.devcontainer/a30/support/patches/package/m4/000-fix-fseeko.patch
+++ b/.devcontainer/a30/support/patches/package/m4/000-fix-fseeko.patch
@@ -1,0 +1,131 @@
+From c79aedf13fe693da0fc5c4ff727aed5bd43526dc Mon Sep 17 00:00:00 2001
+From: Hutson Betts <hutson@hyper-expanse.net>
+Date: Thu, 10 Dec 2020 21:13:54 -0600
+Subject: [PATCH] glibc 2.28
+
+
+diff --git a/lib/fflush.c b/lib/fflush.c
+index ef2a7f1..787790d 100644
+--- a/lib/fflush.c
++++ b/lib/fflush.c
+@@ -33,7 +33,7 @@
+ #undef fflush
+ 
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+ /* Clear the stream's ungetc buffer, preserving the value of ftello (fp).  */
+ static void
+@@ -72,7 +72,7 @@ clear_ungetc_buffer (FILE *fp)
+ 
+ #endif
+ 
+-#if ! (defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
++#if ! (defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
+ 
+ # if (defined __sferror || defined __DragonFly__ || defined __ANDROID__) && defined __SNPT
+ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+@@ -148,7 +148,7 @@ rpl_fflush (FILE *stream)
+   if (stream == NULL || ! freading (stream))
+     return fflush (stream);
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+   clear_ungetc_buffer_preserving_position (stream);
+ 
+diff --git a/lib/fpending.c b/lib/fpending.c
+index ce93604..9fe7ffb 100644
+--- a/lib/fpending.c
++++ b/lib/fpending.c
+@@ -32,7 +32,7 @@ __fpending (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return fp->_IO_write_ptr - fp->_IO_write_base;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+diff --git a/lib/fpurge.c b/lib/fpurge.c
+index 53ee68c..7cba3a3 100644
+--- a/lib/fpurge.c
++++ b/lib/fpurge.c
+@@ -62,7 +62,7 @@ fpurge (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_IO_read_end = fp->_IO_read_ptr;
+   fp->_IO_write_ptr = fp->_IO_write_base;
+   /* Avoid memory leak when there is an active ungetc buffer.  */
+diff --git a/lib/freadahead.c b/lib/freadahead.c
+index cfc969b..5e43e13 100644
+--- a/lib/freadahead.c
++++ b/lib/freadahead.c
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+diff --git a/lib/freading.c b/lib/freading.c
+index 05cb0b8..f1da5b9 100644
+--- a/lib/freading.c
++++ b/lib/freading.c
+@@ -31,7 +31,7 @@ freading (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return ((fp->_flags & _IO_NO_WRITES) != 0
+           || ((fp->_flags & (_IO_NO_READS | _IO_CURRENTLY_PUTTING)) == 0
+               && fp->_IO_read_base != NULL));
+diff --git a/lib/fseeko.c b/lib/fseeko.c
+index 0c01c4f..0601619 100644
+--- a/lib/fseeko.c
++++ b/lib/fseeko.c
+@@ -47,7 +47,7 @@ fseeko (FILE *fp, off_t offset, int whence)
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -123,7 +123,7 @@ fseeko (FILE *fp, off_t offset, int whence)
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+       fp->_offset = pos;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+diff --git a/lib/stdio-impl.h b/lib/stdio-impl.h
+index 766d693..75fe3ad 100644
+--- a/lib/stdio-impl.h
++++ b/lib/stdio-impl.h
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 
+-- 
+2.25.1
+

--- a/.devcontainer/a30/support/relocate-sdk.sh
+++ b/.devcontainer/a30/support/relocate-sdk.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+if [ "$#" -ne 0 ]; then
+    echo "Run this script to relocate the buildroot SDK at that location"
+    exit 1
+fi
+
+FILEPATH="$(readlink -f "$0")"
+NEWPATH="$(dirname "${FILEPATH}")"
+
+cd "${NEWPATH}"
+LOCFILE="sdk-location"
+if [ ! -r "${LOCFILE}" ]; then
+    echo "Previous location of the buildroot SDK not found!"
+    exit 1
+fi
+OLDPATH="$(cat "${LOCFILE}")"
+
+if [ "${NEWPATH}" = "${OLDPATH}" ]; then
+    echo "This buildroot SDK has already been relocated!"
+    exit 0
+fi
+
+# Check if the path substitution does work properly, e.g.  a tree
+# "/a/b/c" copied into "/a/b/c/a/b/c/" would not be allowed.
+newpath="$(sed -e "s|${OLDPATH}|${NEWPATH}|g" "${LOCFILE}")"
+if [ "${NEWPATH}" != "${newpath}" ]; then
+    echo "Something went wrong with substituting the path!"
+    echo "Please choose another location for your SDK!"
+    exit 1
+fi
+
+echo "Relocating the buildroot SDK from ${OLDPATH} to ${NEWPATH} ..."
+
+# Make sure file uses the right language
+export LC_ALL=C
+# Replace the old path with the new one in all text files
+grep -lr "${OLDPATH}" . | while read -r FILE ; do
+    if file -b --mime-type "${FILE}" | grep -q '^text/' && [ "${FILE}" != "${LOCFILE}" ]
+    then
+        sed -i "s|${OLDPATH}|${NEWPATH}|g" "${FILE}"
+    fi
+done
+
+# At the very end, we update the location file to not break the
+# SDK if this script gets interruted.
+sed -i "s|${OLDPATH}|${NEWPATH}|g" ${LOCFILE}

--- a/.devcontainer/a30/support/sdk-location
+++ b/.devcontainer/a30/support/sdk-location
@@ -1,0 +1,1 @@
+/root/buildroot/output/host

--- a/.devcontainer/a30/support/sdl2-update-to-2.26.1.patch
+++ b/.devcontainer/a30/support/sdl2-update-to-2.26.1.patch
@@ -1,0 +1,22 @@
+diff -ru a/package/sdl2/sdl2.hash b/package/sdl2/sdl2.hash
+--- a/package/sdl2/sdl2.hash	2017-11-30 16:35:17.000000000 -0500
++++ b/package/sdl2/sdl2.hash	2024-01-01 21:25:37.000000000 -0500
+@@ -1,4 +1,2 @@
+-# Locally calculated after checking http://www.libsdl.org/release/SDL2-2.0.7.tar.gz.sig
+-sha256 ee35c74c4313e2eda104b14b1b86f7db84a04eeab9430d56e001cea268bf4d5e  SDL2-2.0.7.tar.gz
+-# Locally calculated
+-sha256 bbd2edb1789c33de29bb9f8d1dbe2774584a9ce8c4e3162944b7a3a447f5e85d  COPYING.txt
++# Locally calculated after checking http://www.libsdl.org/release/SDL2-2.26.1.tar.gz.sig
++sha256 02537cc7ebd74071631038b237ec4bfbb3f4830ba019e569434da33f42373e04  SDL2-2.26.1.tar.gz
+diff -ru a/package/sdl2/sdl2.mk b/package/sdl2/sdl2.mk
+--- a/package/sdl2/sdl2.mk	2017-11-30 16:35:17.000000000 -0500
++++ b/package/sdl2/sdl2.mk	2024-01-01 21:18:12.000000000 -0500
+@@ -4,7 +4,7 @@
+ #
+ ################################################################################
+ 
+-SDL2_VERSION = 2.0.7
++SDL2_VERSION = 2.26.1
+ SDL2_SOURCE = SDL2-$(SDL2_VERSION).tar.gz
+ SDL2_SITE = http://www.libsdl.org/release
+ SDL2_LICENSE = Zlib

--- a/.devcontainer/a30/support/setup-env.sh
+++ b/.devcontainer/a30/support/setup-env.sh
@@ -1,0 +1,4 @@
+export PATH="/opt/my282-toolchain/usr/bin:${PATH}:/opt/my282-toolchain/usr/arm-buildroot-linux-gnueabihf/sysroot/bin"
+export CROSS_COMPILE=/opt/my282-toolchain/usr/bin/arm-buildroot-linux-gnueabihf-
+export PREFIX=/opt/my282-toolchain/usr/arm-buildroot-linux-gnueabihf/sysroot/usr
+export UNION_PLATFORM=my282

--- a/.devcontainer/a30/support/toolchain-expose-BR2_TOOLCHAIN_EXTRA_EXTERNAL_LIBS-for-all-toolchain-types-2017.11.1.diff
+++ b/.devcontainer/a30/support/toolchain-expose-BR2_TOOLCHAIN_EXTRA_EXTERNAL_LIBS-for-all-toolchain-types-2017.11.1.diff
@@ -1,0 +1,89 @@
+diff --git a/Config.in.legacy b/Config.in.legacy
+index d4f3d04062..b3086300e6 100644
+--- a/Config.in.legacy
++++ b/Config.in.legacy
+@@ -147,6 +147,17 @@ endif
+ 
+ comment "Legacy options removed in 2017.11"
+ 
++config BR2_TOOLCHAIN_EXTRA_EXTERNAL_LIBS
++	string "toolchain-external extra libs option has been renamed"
++	help
++	  The option BR2_TOOLCHAIN_EXTRA_EXTERNAL_LIBS has
++	  been renamed to BR2_TOOLCHAIN_EXTRA_LIBS.
++
++config BR2_TOOLCHAIN_EXTRA_EXTERNAL_LIBS_WRAP
++	bool
++	default y if BR2_TOOLCHAIN_EXTRA_EXTERNAL_LIBS != ""
++	select BR2_LEGACY
++
+ config BR2_PACKAGE_RFKILL
+ 	bool "rfkill package removed"
+ 	select BR2_LEGACY
+diff --git a/package/gcc/gcc-final/gcc-final.mk b/package/gcc/gcc-final/gcc-final.mk
+index 30fb87856c..24d034b720 100644
+--- a/package/gcc/gcc-final/gcc-final.mk
++++ b/package/gcc/gcc-final/gcc-final.mk
+@@ -187,6 +187,8 @@ ifeq ($(BR2_GCC_ENABLE_OPENMP),y)
+ HOST_GCC_FINAL_USR_LIBS += libgomp
+ endif
+ 
++HOST_GCC_FINAL_USR_LIBS += $(call qstrip,$(BR2_TOOLCHAIN_EXTRA_LIBS))
++
+ ifneq ($(HOST_GCC_FINAL_USR_LIBS),)
+ define HOST_GCC_FINAL_INSTALL_STATIC_LIBS
+ 	for i in $(HOST_GCC_FINAL_USR_LIBS) ; do \
+diff --git a/toolchain/Config.in b/toolchain/Config.in
+index c9aa95985f..8f990cacb9 100644
+--- a/toolchain/toolchain-common.in
++++ b/toolchain/toolchain-common.in
+@@ -82,6 +82,19 @@ config BR2_TOOLCHAIN_GLIBC_GCONV_LIBS_LIST
+ 
+ 	  Note: the full set of gconv libs are ~8MiB (on ARM).
+ 
++config BR2_TOOLCHAIN_EXTRA_LIBS
++	string "Extra toolchain libraries to be copied to target"
++	default ""
++	help
++	  If your toolchain provides extra libraries that need to be
++	  copied to the target filesystem, enter them here, separated
++	  by spaces.
++
++	  NOTE: The library name should not include a suffix or wildcard.
++
++	  Examples where this can be useful is for adding debug libraries
++	  to the target like the GCC libsanitizer (libasan/liblsan/...).
++
+ # This boolean is true if the toolchain provides a built-in full
+ # featured gettext implementation (glibc), and false if only a stub
+ # gettext implementation is provided (uclibc, musl)
+diff --git a/toolchain/toolchain-external/pkg-toolchain-external.mk b/toolchain/toolchain-external/pkg-toolchain-external.mk
+index 5147da0104..e339773a96 100644
+--- a/toolchain/toolchain-external/pkg-toolchain-external.mk
++++ b/toolchain/toolchain-external/pkg-toolchain-external.mk
+@@ -156,7 +156,7 @@ ifeq ($(BR2_TOOLCHAIN_HAS_DLANG),y)
+ TOOLCHAIN_EXTERNAL_LIBS += libgdruntime.so* libgphobos.so*
+ endif
+ 
+-TOOLCHAIN_EXTERNAL_LIBS += $(call qstrip,$(BR2_TOOLCHAIN_EXTRA_EXTERNAL_LIBS))
++TOOLCHAIN_EXTERNAL_LIBS += $(call qstrip,$(BR2_TOOLCHAIN_EXTRA_LIBS))
+ 
+ 
+ #
+diff --git a/toolchain/toolchain-external/toolchain-external-custom/Config.in.options b/toolchain/toolchain-external/toolchain-external-custom/Config.in.options
+index a36747f490..fd95f8201b 100644
+--- a/toolchain/toolchain-external/toolchain-external-custom/Config.in.options
++++ b/toolchain/toolchain-external/toolchain-external-custom/Config.in.options
+@@ -438,12 +438,4 @@ config BR2_TOOLCHAIN_EXTERNAL_OPENMP
+ 	  support. If you don't know, leave the default value,
+ 	  Buildroot will tell you if it's correct or not.
+ 
+-config BR2_TOOLCHAIN_EXTRA_EXTERNAL_LIBS
+-	string "Extra toolchain libraries to be copied to target"
+-	help
+-	  If your external toolchain provides extra libraries that
+-	  need to be copied to the target filesystem, enter them
+-	  here, separated by spaces. They will be copied to the
+-	  target's /lib directory.
+-
+ endif

--- a/.devcontainer/brick/Dockerfile
+++ b/.devcontainer/brick/Dockerfile
@@ -1,0 +1,35 @@
+# adapted from https://github.com/shauninman/union-tg3040-toolchain
+FROM debian:buster-slim
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get -y update && apt-get -y install \
+	bc \
+    build-essential \
+    bzip2 \
+	bzr \
+	cmake \
+	cmake-curses-gui \
+	cpio \
+	git \
+	libncurses5-dev \
+	libsdl1.2-dev \
+	libsdl-image1.2-dev \
+	libsdl-ttf2.0-dev \
+	libsdl2-dev \
+	libsdl2-image-dev \
+	libsdl2-ttf-dev \
+	locales \
+	make \
+	rsync \
+	scons \
+	tree \
+	unzip \
+	wget \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY support .
+RUN ./setup-toolchain.sh
+RUN cat setup-env.sh >> ~/.bashrc

--- a/.devcontainer/brick/devcontainer.json
+++ b/.devcontainer/brick/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "Brick",
+  "build": { "dockerfile": "Dockerfile" }
+}

--- a/.devcontainer/brick/support/setup-env.sh
+++ b/.devcontainer/brick/support/setup-env.sh
@@ -1,0 +1,10 @@
+TOOLCHAIN_ARCH=`uname -m`
+if [ "$TOOLCHAIN_ARCH" = "aarch64" ]; then
+	export CROSS_COMPILE=/usr/bin/aarch64-linux-gnu-   
+	export PREFIX=/usr 
+else
+	export PATH="/opt/aarch64-linux-gnu/aarch64-linux-gnu/bin:${PATH}:/opt/aarch64-linux-gnu/aarch64-linux-gnu/libc/bin"
+	export CROSS_COMPILE=/opt/aarch64-linux-gnu/bin/aarch64-linux-gnu-
+	export PREFIX=/opt/aarch64-linux-gnu/aarch64-linux-gnu/libc/usr
+fi
+export UNION_PLATFORM=tg3040

--- a/.devcontainer/brick/support/setup-toolchain.sh
+++ b/.devcontainer/brick/support/setup-toolchain.sh
@@ -1,0 +1,29 @@
+#! /bin/sh
+
+TOOLCHAIN_ARCH=`uname -m`
+if [ "$TOOLCHAIN_ARCH" = "aarch64" ]; then
+	echo "toolchain is aarch64, exiting"
+	exit
+fi
+
+echo "building toolchain"
+
+SYSROOT_TAR="SDK_usr_tg5040_a133p"
+TOOLCHAIN_NAME="aarch64-linux-gnu"
+TOOLCHAIN_TAR="gcc-arm-8.3-2019.02-x86_64-aarch64-linux-gnu"
+
+TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.02/$TOOLCHAIN_TAR.tar.xz"
+SYSROOT_URL="https://github.com/trimui/toolchain_sdk_smartpro/releases/download/20231018/$SYSROOT_TAR.tgz"
+
+cd ~
+
+wget $TOOLCHAIN_URL
+wget $SYSROOT_URL
+
+tar xf $TOOLCHAIN_TAR.tar.xz -C /opt
+mv /opt/$TOOLCHAIN_TAR /opt/$TOOLCHAIN_NAME
+rm $TOOLCHAIN_TAR.tar.xz
+
+tar xf $SYSROOT_TAR.tgz
+rsync -a --ignore-existing ./usr/ /opt/$TOOLCHAIN_NAME/$TOOLCHAIN_NAME/libc/usr/
+rm -rf ./usr $SYSROOT_TAR.tgz

--- a/easyConfig/global.cpp
+++ b/easyConfig/global.cpp
@@ -1,6 +1,6 @@
 #include "global.h"
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 namespace global
 {

--- a/easyConfig/global.h
+++ b/easyConfig/global.h
@@ -7,9 +7,9 @@
 using std::string;
 using std::map;
 
-#include <SDL.h>
-#include <SDL_image.h>
-#include <SDL_ttf.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
+#include <SDL2/SDL_ttf.h>
 
 namespace global
 {

--- a/easyConfig/image_texture.cpp
+++ b/easyConfig/image_texture.cpp
@@ -1,8 +1,8 @@
 #include "image_texture.h"
 
 #include <iostream>
-#include <SDL.h>
-#include <SDL_image.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
 
 using std::cerr, std::endl;
 

--- a/easyConfig/image_texture.h
+++ b/easyConfig/image_texture.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 #include "texture_base.h"
 

--- a/easyConfig/main.cpp
+++ b/easyConfig/main.cpp
@@ -6,9 +6,9 @@
 #include <stdexcept>
 #include <map>
 
-#include <SDL.h>
-#include <SDL_image.h>
-#include <SDL_ttf.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
+#include <SDL2/SDL_ttf.h>
 
 #include "global.h"
 #include "fileutils.h"

--- a/easyConfig/sdl_unique_ptr.h
+++ b/easyConfig/sdl_unique_ptr.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <type_traits>
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 /**
  * @brief Deletes the SDL surface using `SDL_FreeSurface`.

--- a/easyConfig/text_texture.cpp
+++ b/easyConfig/text_texture.cpp
@@ -1,7 +1,7 @@
 #include "text_texture.h"
 
-#include <SDL.h>
-#include <SDL_image.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
 
 TextTexture::TextTexture(const string & text, TTF_Font *font, SDL_Color color, 
     TextureAlignment alignment)

--- a/easyConfig/text_texture.h
+++ b/easyConfig/text_texture.h
@@ -2,8 +2,8 @@
 #define TEXT_TEXTURE_H
 
 #include <string>
-#include <SDL.h>
-#include <SDL_ttf.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
 
 #include "texture_base.h"
 

--- a/easyConfig/texture_base.cpp
+++ b/easyConfig/texture_base.cpp
@@ -1,8 +1,8 @@
 #include "texture_base.h"
 
 #include <iostream>
-#include <SDL.h>
-#include <SDL_image.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
 
 #include "global.h"
 


### PR DESCRIPTION
- adds dev container setups for the Brick and the A30
    - these are heavily inspired (read: borrowed) from @shauninman's `union-` toolchains
        - https://github.com/shauninman/union-tg3040-toolchain/blob/main/Dockerfile
        - https://github.com/shauninman/union-my282-toolchain
- fully qualify SDL2 imports for `easyConfig` (e.g. `SDL2/SDL.h`)

if you're having trouble with include paths, make sure to add the following:
- `/usr/include/**`
- `/opt/**`